### PR TITLE
EN05 & EE05

### DIFF
--- a/httpdocs/firmware/seeed_display_compatibility.html
+++ b/httpdocs/firmware/seeed_display_compatibility.html
@@ -287,7 +287,7 @@ tbody tr:hover {
         <tbody>
           <tr>
             <td><span class="badge connector-24">24 pin</span></td>
-            <td><a href="https://www.seeedstudio.com/XIAO-ePaper-Display-Board-nRF52840-EN04-p-6589.html" target="_blank" rel="noopener">EN04</a>, <a href="https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html" target="_blank" rel="noopener">EE04</a>, <a href="https://www.seeedstudio.com/ePaper-breakout-Board-for-XIAO-V2-p-6374.html" target="_blank" rel="noopener">ePaper Driver Board for Seeed Studio XIAO</a></td>
+            <td><a href="https://www.seeedstudio.com/XIAO-ePaper-Display-Board-nRF52840-EN04-p-6589.html" target="_blank" rel="noopener">EN04</a>, <a href="https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html" target="_blank" rel="noopener">EE04</a>, <a href="https://www.seeedstudio.com/XIAO-ePaper-DIY-Kit-nRF52840-EN05.html" target="_blank" rel="noopener">EN05</a>, <a href="https://www.seeedstudio.com/XIAO-ePaper-DIY-Kit-ESP32-S3-EE05.html" target="_blank" rel="noopener">EE05</a>, <a href="https://www.seeedstudio.com/ePaper-breakout-Board-for-XIAO-V2-p-6374.html" target="_blank" rel="noopener">ePaper Driver Board for Seeed Studio XIAO</a></td>
           </tr>
           <tr>
             <td><span class="badge connector-50">50 pin</span></td>


### PR DESCRIPTION
Updated links for the Seeed Studio XIAO ePaper display compatibility table.

Both EN05 and EE05 are supported by the toolbox, so they should be added to the list.