### PR TITLE
Add some missing elements for the reTerminal E1002 based on the schematics

### DIFF
--- a/httpdocs/firmware/toolbox/simple-config-presets.json
+++ b/httpdocs/firmware/toolbox/simple-config-presets.json
@@ -343,6 +343,29 @@
             "data": "9",
             "clk": "7"
          },
+         "led": {
+            "instance_number": "0x0",
+            "led_type": "1",
+            "led_1_r": "0x1a",
+            "led_flags": "0x1"
+         },
+         "passiveBuzzer": {
+            "instance_number": "0x0",
+            "drive_pin": "45",
+            "flags": 1
+         },
+         "dataBus": {
+            "instance_number": "0x0",
+            "bus_type": "1",
+            "pin_1": "20",
+            "pin_2": "19"
+         },
+         "sensorData": {
+            "sensor_type": "4",
+            "instance_number": "0",
+            "bus_id": "0x0",
+            "i2c_addr_7bit": "0x44"
+         },
          "powerDefaults": {
             "battery_sense_pin": "1",
             "battery_sense_enable_pin": "21",


### PR DESCRIPTION
This makes an assumption about the passive buzzer since there's no other examples of one being setup for any panels.  I'm referencing the schematics from Seeed Studio https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004321_reTerminal_E1002_V1_2_SCH_251120.pdf directly for pins and configurations (also worked for when doing a custom esphome firmware).  I don't believe there's any mistakes there but feel free to fix anything i've gotten wrong since the syntax of the page data file here is a bit different than the exported config from the toolbox.