### PR TITLE
Add no-break class for "e-paper" and adjust hero title styling (font-size and gap)

### DIFF
--- a/httpdocs/css/home.css
+++ b/httpdocs/css/home.css
@@ -16,6 +16,8 @@ img { display: block; max-width: 100%; }
 button { font: inherit; cursor: pointer; }
 button:active { transform: translateY(1px); box-shadow: none !important; }
 
+.no-break { white-space: nowrap; }
+
 /* 4×4 Bayer ordered dither (50% tone) for mock e-paper surfaces */
 .page-home {
   --ep-dither-tile: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Crect x='1' y='0' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='3' y='0' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='0' y='1' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='2' y='1' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='1' y='2' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='3' y='2' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='0' y='3' width='1' height='1' fill='%230b0f12'/%3E%3Crect x='2' y='3' width='1' height='1' fill='%230b0f12'/%3E%3C/svg%3E");
@@ -434,13 +436,13 @@ a:focus-visible {
   padding: 0 32px;
   display: grid;
   grid-template-columns: minmax(320px, 1.05fr) 1fr;
-  gap: 56px;
+  gap: 42px;
   align-items: center;
 }
 .hero__title {
   font-family: var(--font-sans);
   font-weight: 600;
-  font-size: clamp(44px, 5.4vw, 64px);
+  font-size: clamp(44px, 5.4vw, 56px);
   line-height: 1.02;
   letter-spacing: -0.025em;
   margin: 0;

--- a/httpdocs/index.html
+++ b/httpdocs/index.html
@@ -88,7 +88,7 @@
           <h1 class="hero__title">
             Your data.<br>
             Your screen.<br>
-            <span class="hero__serif">Designed for e-paper.</span>
+            <span class="hero__serif">Designed for <span class="no-break">e-paper</span>.</span>
           </h1>
           <p class="hero__oneliner">
             OpenDisplay is an open standard and open firmware that lets any sender put pictures on any screen. Local, low-power, no cloud in the middle.


### PR DESCRIPTION
Treats "e-paper" as a single word and adds no-wrap to this word. Also adjusted font size and gap to fit everything into a single line.
Tested on Chrome, Edge and Firefox (all latest versions).

Before:
<img width="1138" height="721" alt="image" src="https://github.com/user-attachments/assets/536fd682-9ff0-4531-b7e7-e88135e45262" />
After:
<img width="1139" height="719" alt="image" src="https://github.com/user-attachments/assets/2bd340fd-2cfc-43fb-847f-05bb06723af3" />

Small screen:
Before:
<img width="425" height="629" alt="image" src="https://github.com/user-attachments/assets/5fa9bd69-eb70-4d42-a446-e0e10321ae72" />
After:
<img width="438" height="612" alt="image" src="https://github.com/user-attachments/assets/2ad1ae59-06aa-4c3f-9008-dc3aebbb13d2" />
