### PR TITLE
Harden parseMsd16 against null opts and oversized buffers (opendisplay-msd.js)

### DIFF
--- a/httpdocs/js/opendisplay-msd.js
+++ b/httpdocs/js/opendisplay-msd.js
@@ -149,8 +149,10 @@
    */
   function parseMsd16(msd16, opts) {
     const legacyMode = opts === undefined;
+    // Normalize an explicit `null` opts so the direct `opts.*` reads below don't throw.
+    if (!legacyMode) opts = opts || {};
     const u8 = msd16 instanceof Uint8Array ? msd16 : new Uint8Array(msd16);
-    if (u8.length < 16) {
+    if (u8.length !== 16) {
       return { error: 'Expected 16 bytes, got ' + u8.length };
     }
     const companyId = u8[0] | (u8[1] << 8);
@@ -232,6 +234,9 @@
       },
       buttonBlock,
       touchBlock,
+      // Deprecated alias of `touchBlock`. Despite the name it is NOT necessarily
+      // decoded at offset 0: in config mode it reflects `touchDataStartByte`.
+      // Prefer `touchBlock` (has `.startByte`); kept only for backward compatibility.
       touchBlockAt0: touchBlock,
       sht40At7: sht40At7,
       sht40StartByte: legacyMode ? 7 : opts.sht40StartByte != null ? sht40StartByteUsed : null,

--- a/httpdocs/js/opendisplay-msd.js
+++ b/httpdocs/js/opendisplay-msd.js
@@ -117,7 +117,13 @@
         if (sensorType === SENSOR_TYPE_SHT40 && out.sht40StartByte === null) {
           let start = data[5];
           if (start === 0xff || start === undefined) start = 7;
-          out.sht40StartByte = start & 0xff;
+          start = start & 0xff;
+          // SHT40 reads 3 bytes (start..start+2) from the 11-byte dynamic region,
+          // so start must be <= 8. Validate symmetrically with BQ27220's idx <= 10
+          // check below; fall back to the default (7) rather than reporting an
+          // index that parseMsd16 will never decode.
+          if (start > 8) start = 7;
+          out.sht40StartByte = start;
         }
         if (sensorType === SENSOR_TYPE_BQ27220 && out.bq27220StartByte === null) {
           const idx = data[5] & 0xff;


### PR DESCRIPTION
Robustness fixes in `httpdocs/js/opendisplay-msd.js` found during a static review.

### M1 — `parseMsd16(bytes, null)` throws
`legacyMode` is `opts === undefined`, so an explicit `null` opts is treated as config mode and falls through to `opts.sht40StartByte` / `opts.bq27220StartByte`, throwing *"Cannot read properties of null"*. `resolveOptionalByteIndex` already tolerates a falsy `opts`, but these two direct reads did not. Normalize a non-`undefined` `opts` to `{}` early.

### M2 — oversized buffers silently decoded as garbage
The length guard was `u8.length < 16`, so anything longer than 16 bytes was accepted despite the *"exactly 16 bytes"* contract. Passing the raw 18-byte `0x00 0x44` notification frame decodes company-ID `0x4400` and shifts every field. Changed to require `!== 16`. (The internal `readMsd()` path always supplies exactly 16 bytes, so this only rejects genuine misuse.)

### M3 — `touchBlockAt0` is a misleading alias
In config mode with `touchDataStartByte > 0` the field is not the offset-0 decode its name implies. Documented it as a deprecated backward-compat alias of `touchBlock` (which carries `.startByte`); no rename, to avoid breaking external consumers.

### Verification
Static change; verified by inspection and brace/paren/bracket balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb