### PR TITLE
Fix nRF52 serial-DFU port cleanup and ACK/HCI transport races

### DIFF
--- a/httpdocs/firmware/toolbox/nrf_web_tools.js
+++ b/httpdocs/firmware/toolbox/nrf_web_tools.js
@@ -266,10 +266,17 @@ class NrfWebTools {
     content.innerHTML = `
       <div class="nrf52-dfu-message-page">
         <div class="nrf52-dfu-message-icon">⚠️</div>
-        <p>${data.message || 'An error occurred during the update process.'}</p>
-        ${data.details ? `<p class="nrf52-dfu-error-details">${data.details}</p>` : ''}
+        <p class="nrf52-dfu-error-message"></p>
+        ${data.details ? `<p class="nrf52-dfu-error-details"></p>` : ''}
       </div>
     `;
+    // Set via textContent so error text (which can include zip-manifest
+    // filenames from a loaded package) cannot inject markup into the DOM.
+    content.querySelector('.nrf52-dfu-error-message').textContent =
+      data.message || 'An error occurred during the update process.';
+    if (data.details) {
+      content.querySelector('.nrf52-dfu-error-details').textContent = data.details;
+    }
     actions.innerHTML = `
       <button class="nrf52-dfu-btn nrf52-dfu-btn-secondary" onclick="document.getElementById('nrf52-dfu-modal').querySelector('#nrf52-dfu-close-btn').click()">Close</button>
       ${data.retry ? `<button class="nrf52-dfu-btn nrf52-dfu-btn-primary" id="nrf52-dfu-retry-btn">Retry</button>` : ''}
@@ -746,7 +753,10 @@ class NrfWebTools {
       this.resolveAck = resolve;
       this.ackTimeout = setTimeout(() => {
         this.resolveAck = null;
-        this.hciSequenceNumber = 0;
+        // Do not reset hciSequenceNumber here: sendPacket resends the same pkt
+        // built with the old seq, and the adafruit-nrfutil reference does not
+        // reset on timeout. Resetting desyncs the HCI reliable-transport counter
+        // so one lost ACK could wedge the rest of the transfer.
         reject(new Error("ACK timeout"));
       }, timeout);
     });
@@ -758,11 +768,14 @@ class NrfWebTools {
     let packetSent = false;
     
     while (!packetSent) {
+      // Arm the ACK listener before writing so an ACK that lands immediately
+      // after the write is not dropped by readLoop (which needs resolveAck set).
+      const ackPromise = this.waitForAck();
       await this.writer.write(pkt);
       attempts++;
-      
+
       try {
-        let ack = await this.waitForAck();
+        let ack = await ackPromise;
         if (lastAck === null) {
           lastAck = ack;
           packetSent = true;
@@ -872,25 +885,25 @@ class NrfWebTools {
   }
   
   async disconnectPort() {
-    if (this.port) {
-      try {
-        if (this.reader) {
-          await this.reader.cancel();
-          this.reader.releaseLock();
-          this.reader = null;
-        }
-        if (this.writer) {
-          await this.writer.close();
-          this.writer.releaseLock();
-          this.writer = null;
-        }
-        if (this.port.readable) this.port.readable.releaseLock();
-        if (this.port.writable) this.port.writable.releaseLock();
-        await this.port.close();
-        this.port = null;
-      } catch (closeErr) {
-        // Ignore close errors
+    if (!this.port) return;
+    // ReadableStream/WritableStream have no releaseLock() (only the reader/writer
+    // do), so the old code threw before ever closing the port, leaving it open
+    // with a stale this.port and blocking the next reconnect. Close each step
+    // independently and always null every field in finally.
+    try {
+      if (this.reader) {
+        try { await this.reader.cancel(); } catch (e) {}
+        try { this.reader.releaseLock(); } catch (e) {}
       }
+      if (this.writer) {
+        try { await this.writer.close(); } catch (e) {}
+        try { this.writer.releaseLock(); } catch (e) {}
+      }
+      try { await this.port.close(); } catch (e) {}
+    } finally {
+      this.reader = null;
+      this.writer = null;
+      this.port = null;
     }
   }
   

--- a/httpdocs/nrf_web_tools/nrf_web_tools.js
+++ b/httpdocs/nrf_web_tools/nrf_web_tools.js
@@ -274,10 +274,17 @@ class NrfWebTools {
     content.innerHTML = `
       <div class="nrf52-dfu-message-page">
         <div class="nrf52-dfu-message-icon">⚠️</div>
-        <p>${data.message || 'An error occurred during the update process.'}</p>
-        ${data.details ? `<p class="nrf52-dfu-error-details">${data.details}</p>` : ''}
+        <p class="nrf52-dfu-error-message"></p>
+        ${data.details ? `<p class="nrf52-dfu-error-details"></p>` : ''}
       </div>
     `;
+    // Set via textContent so error text (which can include zip-manifest
+    // filenames from a loaded package) cannot inject markup into the DOM.
+    content.querySelector('.nrf52-dfu-error-message').textContent =
+      data.message || 'An error occurred during the update process.';
+    if (data.details) {
+      content.querySelector('.nrf52-dfu-error-details').textContent = data.details;
+    }
     actions.innerHTML = `
       <button class="nrf52-dfu-btn nrf52-dfu-btn-secondary" onclick="document.getElementById('nrf52-dfu-modal').querySelector('#nrf52-dfu-close-btn').click()">Close</button>
       ${data.retry ? `<button class="nrf52-dfu-btn nrf52-dfu-btn-primary" id="nrf52-dfu-retry-btn">Retry</button>` : ''}
@@ -769,7 +776,10 @@ class NrfWebTools {
       this.resolveAck = resolve;
       this.ackTimeout = setTimeout(() => {
         this.resolveAck = null;
-        this.hciSequenceNumber = 0;
+        // Do not reset hciSequenceNumber here: sendPacket resends the same pkt
+        // built with the old seq, and the adafruit-nrfutil reference does not
+        // reset on timeout. Resetting desyncs the HCI reliable-transport counter
+        // so one lost ACK could wedge the rest of the transfer.
         reject(new Error("ACK timeout"));
       }, timeout);
     });
@@ -781,11 +791,14 @@ class NrfWebTools {
     let packetSent = false;
     
     while (!packetSent) {
+      // Arm the ACK listener before writing so an ACK that lands immediately
+      // after the write is not dropped by readLoop (which needs resolveAck set).
+      const ackPromise = this.waitForAck();
       await this.writer.write(pkt);
       attempts++;
-      
+
       try {
-        let ack = await this.waitForAck();
+        let ack = await ackPromise;
         if (lastAck === null) {
           lastAck = ack;
           packetSent = true;
@@ -895,25 +908,25 @@ class NrfWebTools {
   }
   
   async disconnectPort() {
-    if (this.port) {
-      try {
-        if (this.reader) {
-          await this.reader.cancel();
-          this.reader.releaseLock();
-          this.reader = null;
-        }
-        if (this.writer) {
-          await this.writer.close();
-          this.writer.releaseLock();
-          this.writer = null;
-        }
-        if (this.port.readable) this.port.readable.releaseLock();
-        if (this.port.writable) this.port.writable.releaseLock();
-        await this.port.close();
-        this.port = null;
-      } catch (closeErr) {
-        // Ignore close errors
+    if (!this.port) return;
+    // ReadableStream/WritableStream have no releaseLock() (only the reader/writer
+    // do), so the old code threw before ever closing the port, leaving it open
+    // with a stale this.port and blocking the next reconnect. Close each step
+    // independently and always null every field in finally.
+    try {
+      if (this.reader) {
+        try { await this.reader.cancel(); } catch (e) {}
+        try { this.reader.releaseLock(); } catch (e) {}
       }
+      if (this.writer) {
+        try { await this.writer.close(); } catch (e) {}
+        try { this.writer.releaseLock(); } catch (e) {}
+      }
+      try { await this.port.close(); } catch (e) {}
+    } finally {
+      this.reader = null;
+      this.writer = null;
+      this.port = null;
     }
   }
   
@@ -1207,11 +1220,13 @@ class NrfWebTools {
       await this.disconnectPort();
       
       // Check if this is a connection error and we have more firmware to flash
-      const isConnectionError = e.message && (
-        e.message.includes('Failed to get ACK') || 
-        e.message.includes('ACK timeout') ||
-        e.message.includes('NotFoundError')
-      );
+      // A cancelled port picker throws a DOMException whose *name* is
+      // 'NotFoundError' (its message is "No port selected by the user."), so
+      // check e.name, not e.message, to route cancellation to the reconnect path.
+      const isConnectionError = e.name === 'NotFoundError' || (e.message && (
+        e.message.includes('Failed to get ACK') ||
+        e.message.includes('ACK timeout')
+      ));
       
       if (isConnectionError && this.currentFirmwareIndex < this.firmwareQueue.length) {
         // Connection lost, need to reconnect


### PR DESCRIPTION
Correctness fixes to the nRF52 serial DFU. Shared bugs are fixed in **both** copies — `httpdocs/nrf_web_tools/nrf_web_tools.js` and `httpdocs/firmware/toolbox/nrf_web_tools.js`.

### N1 — HIGH: the port is never actually closed
`disconnectPort()` called `releaseLock()` on `this.port.readable` / `.writable`, but `ReadableStream`/`WritableStream` have no `releaseLock()` (only the reader/writer do). That line threw, the throw was swallowed by the single surrounding `catch`, and `port.close()` / `this.port = null` never ran. Every "clean" disconnect left the serial port open with a stale `this.port`, so the next reconnect to the same device failed with *"Failed to open serial port"* — the concrete dead-end when flashing a multi-part (SoftDevice+bootloader, then app) package. Rewritten to close each step in its own `try/catch` and null every field in `finally`.

### N4 — MEDIUM: dropped-ACK race
`sendPacket()` armed the ACK listener (`waitForAck` sets `resolveAck`) only *after* `await writer.write(pkt)` resolved. An ACK arriving in that window was discarded by `readLoop` → spurious 1s timeout + retransmit. Now the ACK promise is created before the write.

### N5 — MEDIUM: seq reset desyncs HCI reliable transport
`waitForAck()` set `hciSequenceNumber = 0` on timeout, but `sendPacket` then resends the same `pkt` built with the old seq while later packets restart at seq 1 — the bootloader treats wrong-seq packets as retransmissions, so one genuinely-lost ACK can wedge the rest of the transfer. The adafruit-nrfutil reference does not reset on timeout. Removed the reset.

### N7 — LOW (newer copy): cancellation misrouted
A cancelled port picker throws a `DOMException` whose **name** is `NotFoundError` but whose message is *"No port selected by the user."* The message-based check missed it and fell through to a generic *"Installation failed"* instead of the reconnect path. Now checks `e.name` (matching how `performFlash()`/`reconnectAndContinue()` already do it).

### N9 — LOW (security): unescaped error text
`renderErrorPage()` interpolated raw `err.message`/`err.details` (which can include zip-manifest filenames from a loaded package) into `innerHTML` — a DOM-injection vector. Now set via `textContent`.

### Deferred (need in-browser or protocol-reference verification)
- **N2** — consolidating the two divergent copies onto one source (the toolbox copy still lacks the reconnect flow). Larger, structural; left for a follow-up.
- **N3 / N8** — DFU INSTALLING re-render and per-frame allocation perf. Timing-sensitive; wants Performance-panel confirmation.
- **N6** — ACK-number validation. The expected ACK relationship (echo-seq vs `(seq+1)%8`) can't be confirmed statically, and getting it wrong would fail *every* packet, so it's unsafe to change blind.

### Verification
Static change (no JS runtime in CI). Verified by inspection; brace/paren/bracket balance preserved in both files. The two copies remain byte-identical for the touched functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb