### PR TITLE
Fix unhandled rejection and byte-reordering in web-serial polyfill (serial.js)

### DIFF
--- a/httpdocs/firmware/toolbox/serial.js
+++ b/httpdocs/firmware/toolbox/serial.js
@@ -99,7 +99,11 @@ class UsbEndpointUnderlyingSource {
      * @param {ReadableByteStreamController} controller
      */
     pull(controller) {
-        (async () => {
+        // Return the promise so the stream serializes pulls (real backpressure):
+        // without this, a read while a transferIn is in flight can start a second
+        // concurrent transferIn on the same endpoint and silently reorder bytes,
+        // which is catastrophic for the SLIP/HCI DFU layer on top.
+        return (async () => {
             var _a;
             let chunkSize;
             if (controller.desiredSize) {
@@ -114,6 +118,9 @@ class UsbEndpointUnderlyingSource {
                 if (result.status != 'ok') {
                     controller.error(`USB error: ${result.status}`);
                     this.onError_();
+                    // Return: enqueue() on an errored controller throws, and USB can
+                    // return data alongside a non-ok status.
+                    return;
                 }
                 if ((_a = result.data) === null || _a === void 0 ? void 0 : _a.buffer) {
                     const chunk = new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength);
@@ -256,18 +263,22 @@ export class SerialPort {
      * closed.
      */
     async close() {
-        const promises = [];
+        // Best-effort per-stream cleanup: cancel()/abort() reject if the consumer
+        // still holds a reader/writer lock, which used to reject the Promise.all
+        // and skip device_.close() entirely — leaving the USB interface claimed.
         if (this.readable_) {
-            promises.push(this.readable_.cancel());
+            try { await this.readable_.cancel(); } catch (e) { }
         }
         if (this.writable_) {
-            promises.push(this.writable_.abort());
+            try { await this.writable_.abort(); } catch (e) { }
         }
-        await Promise.all(promises);
         this.readable_ = null;
         this.writable_ = null;
         if (this.device_.opened) {
-            await this.setSignals({ dataTerminalReady: false, requestToSend: false });
+            // Wrap setSignals so its failure can't skip the load-bearing close().
+            try {
+                await this.setSignals({ dataTerminalReady: false, requestToSend: false });
+            } catch (e) { }
             await this.device_.close();
         }
     }


### PR DESCRIPTION
Upstream-bug fixes in the vendored `httpdocs/firmware/toolbox/serial.js` (google/web-serial-polyfill). These matter for the Android/WebUSB serial-DFU path.

### S1 — unhandled promise rejection in `pull()`
On a non-ok transfer status `pull()` calls `controller.error(...)` but then falls through to `controller.enqueue(chunk)` when `result.data?.buffer` is set (USB can return data alongside a non-ok status). `enqueue()` on an errored controller throws, and the async IIFE is neither awaited nor `.catch`ed → unhandled promise rejection. Added a `return` after the error.

### S2 — overlapping `transferIn` → byte reordering
`pull()` did not return the async IIFE's promise, so the stream treated each pull as settled immediately. A `read()` while a `transferIn` is in flight could start a second concurrent `transferIn()` on the same endpoint with no completion ordering — silent byte reordering, catastrophic for the SLIP/HCI DFU layer on top. Now returns the promise, serializing pulls and giving real backpressure.

### S3 — `close()` leaves the USB device open
`readable_.cancel()` / `writable_.abort()` were run through `Promise.all`, which rejects if the consumer still holds a reader/writer lock — so `device_.close()` never ran and the interface stayed claimed until page unload (compounds the port-cleanup bug in the nRF DFU tool). Now best-effort per-stream cleanup so `device_.close()` always runs.

### Left as-is
Harmless upstream quirks: S4 (255-byte high-water mark), `kAcceptableDataBits` including 16, `isValidBaudRate` accepting 0/negative.

### Verification
Static change; verified by inspection and brace/paren/bracket balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb