### PR TITLE
Fix QR byte-count, type-number, UTF-8 and failed-render download bugs

### DIFF
--- a/httpdocs/l/generateqr.html
+++ b/httpdocs/l/generateqr.html
@@ -285,7 +285,11 @@
       var correctLevelMap = { L: QRCode.CorrectLevel.L, M: QRCode.CorrectLevel.M, Q: QRCode.CorrectLevel.Q, H: QRCode.CorrectLevel.H };
 
       function getQRModel() {
-        return qr && qr._oQRCode ? qr._oQRCode : null;
+        // _oQRCode is assigned before make() runs, so on a failed render it is a
+        // half-built model with moduleCount 0. Require a rendered model so the
+        // download buttons stay disabled and never emit a degenerate 0x0 file.
+        var m = qr && qr._oQRCode ? qr._oQRCode : null;
+        return m && m.getModuleCount && m.getModuleCount() > 0 ? m : null;
       }
 
       function downloadSVG() {

--- a/httpdocs/l/qrcode.js
+++ b/httpdocs/l/qrcode.js
@@ -34,18 +34,22 @@ var QRCode;
 		// Added to support UTF-8 Characters
 		for (var i = 0, l = this.data.length; i < l; i++) {
 			var byteArray = [];
-			var code = this.data.charCodeAt(i);
+			var code = this.data.codePointAt(i);
+			// codePointAt returns the full code point; advance past the low
+			// surrogate of a pair so emoji are not re-encoded as CESU-8. The
+			// boundaries below are >= (U+0080/U+0800/U+10000 start the next tier).
+			if (code > 0xFFFF) i++;
 
-			if (code > 0x10000) {
+			if (code >= 0x10000) {
 				byteArray[0] = 0xF0 | ((code & 0x1C0000) >>> 18);
 				byteArray[1] = 0x80 | ((code & 0x3F000) >>> 12);
 				byteArray[2] = 0x80 | ((code & 0xFC0) >>> 6);
 				byteArray[3] = 0x80 | (code & 0x3F);
-			} else if (code > 0x800) {
+			} else if (code >= 0x800) {
 				byteArray[0] = 0xE0 | ((code & 0xF000) >>> 12);
 				byteArray[1] = 0x80 | ((code & 0xFC0) >>> 6);
 				byteArray[2] = 0x80 | (code & 0x3F);
-			} else if (code > 0x80) {
+			} else if (code >= 0x80) {
 				byteArray[0] = 0xC0 | ((code & 0x7C0) >>> 6);
 				byteArray[1] = 0x80 | (code & 0x3F);
 			} else {
@@ -470,7 +474,7 @@ var QRCode;
 		var nType = 1;
 		var length = _getUTF8Length(sText);
 		
-		for (var i = 0, len = QRCodeLimitLength.length; i <= len; i++) {
+		for (var i = 0, len = QRCodeLimitLength.length; i < len; i++) {
 			var nLimit = 0;
 			
 			switch (nCorrectLevel) {
@@ -504,7 +508,7 @@ var QRCode;
 
 	function _getUTF8Length(sText) {
 		var replacedText = encodeURI(sText).toString().replace(/\%[0-9a-fA-F]{2}/g, 'a');
-		return replacedText.length + (replacedText.length != sText ? 3 : 0);
+		return replacedText.length + (replacedText.length != sText.length ? 3 : 0);
 	}
 	
 	/**


### PR DESCRIPTION
Correctness fixes in the vendored `httpdocs/l/qrcode.js` (davidshimjs/qrcodejs) and the `httpdocs/l/generateqr.html` page.

### Q1 — `_getUTF8Length` compares a number to a string
`replacedText.length + (replacedText.length != sText ? 3 : 0)` compares a number to the whole string `sText`, so the +3 BOM allowance is added for nearly all input, including pure ASCII. This disagrees with the page's own (correct) counter and can push the chosen version one higher than needed near a boundary. Compare to `sText.length`.

### Q2 — `_getTypeNumber` walks past the capacity table
`for (var i = 0, len = QRCodeLimitLength.length; i <= len; i++)` iterates one past the 40-entry table, so over-capacity data reads `QRCodeLimitLength[40]` (undefined) and throws a cryptic `TypeError`, leaving the intended `throw new Error("Too long data")` as dead code. Changed to `i < len` so the real error path runs.

### Q3 — `QR8bitByte` surrogate handling and UTF-8 boundaries
`charCodeAt` with `>` boundaries meant emoji encoded as CESU-8 (mojibake in scanners), U+0080/U+0800 encoded as overlong/invalid UTF-8, and the 4-byte branch was unreachable. Now uses `codePointAt` with a surrogate-skip and `>=` boundaries for correct UTF-8 (the byte-splitting math was already correct).

### Q4 — failed render re-enables downloads → degenerate 0×0 file
`_oQRCode` is assigned before `make()` can throw, so on a failed render (e.g. over-capacity) `getQRModel()` returned the half-built model (`moduleCount === 0`), the download buttons were re-enabled, and the download emitted a degenerate 0×0 SVG/PNG. `getQRModel()` now requires `moduleCount > 0`, which gates both the buttons and the two download handlers.

### Not addressed
Q5 low/cosmetic items (shared `Drawing` mutation across SVG/canvas instances, the download object-URL revoke race, the missing 4-module quiet zone in downloads), some of which live in `l/index.html`.

### Verification
Static change; verified by inspection and brace/paren/bracket balance. The UTF-8 byte math is unchanged; only the code-point iteration and comparison boundaries were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb