### PR TITLE
Fix iOS/Bluefy optionalServices and enable the device-request fallback

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -412,15 +412,29 @@ class OpenDisplayBLE {
     const discoveryFilters = [mfgFilter, serviceFilter, ...nameFilters];
 
     if (this.usesUnfilteredBleScan()) {
+      // acceptAllDevices lets the user *select* any device, but GATT services
+      // are still only accessible if declared in optionalServices — without it,
+      // getPrimaryService(this.serviceUUID) rejects with a SecurityError right
+      // after selection.
       return [{
-        acceptAllDevices: true
+        acceptAllDevices: true,
+        optionalServices: [serviceUuid]
       }];
     }
 
-    return [{
-      optionalServices: [serviceUuid],
-      filters: discoveryFilters
-    }];
+    return [
+      {
+        optionalServices: [serviceUuid],
+        filters: discoveryFilters
+      },
+      {
+        // Fallback: some older Chromium builds reject a manufacturerData filter
+        // with a "payload ... parse" error. Retry with name/service-only filters
+        // (this is the attempt the retry loop in requestBleDevice falls back to).
+        optionalServices: [serviceUuid],
+        filters: [serviceFilter, ...nameFilters]
+      }
+    ];
   }
 
   isRequestDevicePayloadError(error) {


### PR DESCRIPTION
Two issues in `buildRequestDeviceOptionAttempts` / `requestBleDevice` (`httpdocs/js/ble-common.js`), surfaced by re-analysis after the Bluefy support commit.

### B1 — HIGH: iOS/Bluefy path drops `optionalServices`, so service discovery fails
The unfiltered-scan branch returned `{ acceptAllDevices: true }` with no `optionalServices`. In Web Bluetooth, `acceptAllDevices` only lets the user *select* any device — GATT services are still only accessible if declared in `optionalServices`. `connectToGATT()` then calls `getPrimaryService(this.serviceUUID)`, which rejects with `SecurityError: … must be in optionalServices` on any spec-compliant stack. So on iOS/Bluefy the device is found ("Found: …" logs) and service discovery immediately fails — the feature the Bluefy commit added breaks one step after selection.

```js
return [{ acceptAllDevices: true, optionalServices: [serviceUuid] }];
```

### B8 — LOW: the device-request retry loop was dead code
`buildRequestDeviceOptionAttempts` always returned a single-element array, so the `isRequestDevicePayloadError(error) && i !== attempts.length - 1` retry branch in `requestBleDevice` was unreachable. The desktop filter set includes a `manufacturerData` filter that some older Chromium builds reject with a "payload … parse" error; the retry was clearly meant to fall back to a name/service-only filter, but no second attempt existed. Added a manufacturerData-free fallback attempt so the loop has something to retry with.

### Verification
Static change (no JS runtime in CI); verified by inspection and brace/paren/bracket balance. B1 should be smoke-tested on an actual iOS/Bluefy device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb