### PR TITLE
Fix upload stall on send failure and phantom etag on fast-refresh partial

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -3954,6 +3954,11 @@ if (supportsStreamingDecompression) {
       
       this.sendHexCommand('0071' + chunkHex).catch(err => {
         this.log('Error sending chunk: ' + err.message, 'error');
+        // The send failed terminally (sendHexCommand already retries GATT-busy
+        // errors). chunkIndex/pendingAcks advanced synchronously, so no 0x71 ACK
+        // will ever arrive for this chunk and the upload would otherwise hang
+        // forever with onComplete never called. Abort and surface the error.
+        this._abortDirectWrite(err);
       });
       state.chunkIndex++;
       state.pendingAcks++;
@@ -3974,14 +3979,33 @@ if (supportsStreamingDecompression) {
       
       if (state.mode === 'partial') {
         this.sendHexCommand(this.buildDirectWriteEndHex(2));
+      } else if (state.trackPartial && state.newEtag) {
+        // Send the etag-bearing end payload so the firmware stores displayed_etag
+        // (handleDirectWriteEnd only stores it for payloads of length >= 5),
+        // while preserving the fast-refresh mode. Previously a fast-refresh upload
+        // sent a 1-byte end (007201, no etag) yet _commitPartialState still
+        // recorded newEtag, so every subsequent partial update etag-mismatched and
+        // fell back to full — partial updates never actually happened.
+        const refreshMode = state.useFastRefresh ? 1 : 0;
+        this.sendHexCommand(this.buildDirectWriteEndHex(refreshMode, state.newEtag));
       } else if (state.useFastRefresh) {
         this.sendHexCommand('007201');
-      } else if (state.trackPartial && state.newEtag) {
-        this.sendHexCommand(this.buildDirectWriteEndHex(0, state.newEtag));
       } else {
         this.sendHexCommand('0072');
       }
     }
+  }
+
+  /**
+   * Abort an in-flight direct write and surface the error to onComplete.
+   */
+  _abortDirectWrite(err) {
+    const state = this.directWriteState;
+    if (!state || !state.active) return;
+    state.active = false;
+    const onComplete = state.onComplete;
+    this.directWriteState = null;
+    if (onComplete) onComplete(false, err);
   }
 
   /**


### PR DESCRIPTION
Two correctness bugs in the direct-write image upload path in `httpdocs/js/ble-common.js`.

### B2 — MEDIUM: a failed chunk send hangs the upload forever
`sendNextDirectWriteChunk` sends each chunk fire-and-forget and advances `chunkIndex`/`pendingAcks` synchronously; the `.catch` only logged. `sendHexCommand` retries GATT-busy `NetworkError`s, but any other terminal rejection (disconnect mid-upload, encryption failure) meant the chunk was never sent — so no `0x71` ACK arrives, `sendNextDirectWriteChunk` is never re-entered, the terminal `chunkIndex >= length && pendingAcks === 0` branch is never reached, and the transfer hangs forever with `onComplete` never called. The UI stays on *"Uploading… X%"*. Now aborts the write and surfaces the error via `onComplete(false, err)` (new `_abortDirectWrite` helper, guarded so only the first failure fires).

### B3 — MEDIUM: fast-refresh + partial tracking commits a phantom etag
When both `useFastRefresh` and `trackPartial` were set, the end-command selection sent `007201` — a 1-byte end payload with no etag — but firmware `handleDirectWriteEnd` only stores `displayed_etag` for end payloads of length ≥ 5. The JS still committed `newEtag` to `partialState`, so the next `sendCanvasToDisplay` sent an `oldEtag` the device never stored → `ERR_ETAG_MISMATCH` NACK → `_fallbackToFullDirectWrite()`. Net effect: **fast-refresh displays never actually used the partial path** — every frame silently re-uploaded full.

Fix: when tracking partial with an etag, send the etag-bearing end payload while preserving the refresh mode (`buildDirectWriteEndHex(1, etag)` for fast refresh — a valid 5-byte end the firmware stores the etag for). This aligns the end command with the `_commitPartialState` call and enables partial updates for fast-refresh displays.

### Verification
Static change; verified by inspection and brace/paren/bracket balance. B3 relies on the firmware contract noted in the finding (etag stored when end payload len ≥ 5); worth an on-device confirmation that a subsequent partial update now takes the `0x76` path instead of falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb