### PR TITLE
Fix encrypted-response size gate off-by-one that can clear the session

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -1695,8 +1695,11 @@ class OpenDisplayBLE {
     
     // Check if response is encrypted
     // Minimum encrypted response size: 2 (header) + 16 (nonce) + 1 (length byte) + 0 (min payload) + 12 (tag) = 31 bytes
-    // If response is shorter than 30 bytes, it's definitely unencrypted
-    const MIN_ENCRYPTED_RESPONSE_SIZE = 30;
+    // If response is shorter than 31 bytes, it's definitely unencrypted. Using 30
+    // let a 30-byte frame — which can never be valid ciphertext — reach
+    // decryptResponse, where it fails and counts toward integrityFailures; three
+    // such frames force-clear the authenticated session mid-operation.
+    const MIN_ENCRYPTED_RESPONSE_SIZE = 31;
     const isPotentiallyEncrypted = bytes.length >= MIN_ENCRYPTED_RESPONSE_SIZE;
     
     if (this.encryptionSession.authenticated && bytes.length >= 2 && isPotentiallyEncrypted) {


### PR DESCRIPTION
### B7 — `MIN_ENCRYPTED_RESPONSE_SIZE` off-by-one force-clears the session
The minimum valid encrypted frame is `2 (header) + 16 (nonce) + 1 (length) + 0 (min payload) + 12 (tag) = 31` bytes — the code comment already says 31 — but the gate used `>= 30`. A 30-byte frame can never be valid ciphertext, yet it passed the gate and reached `decryptResponse`, which slices a 0-byte ciphertext, fails tag verification, and increments `integrityFailures`. Three such failures set `authenticated = false` and tear down encryption mid-operation.

Fix: gate on `>= 31`. Because the firmware encrypts every response ≥ 31 bytes while authenticated (the only unencrypted responses are the 3-byte `0xFE`/`0xFF` status frames and the `0x50`/`0x43` responses already skipped above), only genuine ciphertext now reaches `decryptResponse`, so the spurious `integrityFailures` no longer occur.

I deliberately did **not** change the `integrityFailures` escalation accounting (the finding's secondary suggestion): once the gate matches the firmware's "≥31 ⇒ encrypted" guarantee, no legitimate unencrypted response reaches `decryptResponse`, so the accounting change is unnecessary — and loosening the tamper/replay escalation on a length heuristic would weaken a real security mechanism.

### Verification
One-constant change; verified by inspection. Behavior for all real frame sizes is unchanged except that a 30-byte frame is now treated as plaintext (which it always is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb