### PR TITLE
Harden hero-display, battery-widget, and home.js against edge cases

### DIFF
--- a/httpdocs/js/battery-widget.js
+++ b/httpdocs/js/battery-widget.js
@@ -48,6 +48,16 @@
   var displayPicker = root.querySelector('[data-picker-group="display"]');
   var chipPicker = root.querySelector('[data-picker-group="chip"]');
 
+  // render() and the event wiring below dereference all of these; bail if the
+  // markup is incomplete rather than throwing mid-setup and aborting the widget.
+  // (elEspWarn is genuinely optional and is null-checked at its use site.)
+  if (!elCapacity || !elInterval || !elStandby || !elLifeValue || !elLifeUnit ||
+      !elLifeSub || !elRefreshPct || !elRefreshMah || !elRefreshSub || !elStandbyPct ||
+      !elStandbyMah || !elStandbySub || !elDailyMah || !elDailySub || !elRange ||
+      !displayPicker || !chipPicker) {
+    return;
+  }
+
   var CHIP_SVG =
     '<svg width="28" height="22" viewBox="0 0 28 22" fill="none" aria-hidden="true">' +
     '<rect x="6" y="3" width="16" height="16" rx="1.5" stroke="currentColor" stroke-width="1.5"/>' +

--- a/httpdocs/js/hero-display.js
+++ b/httpdocs/js/hero-display.js
@@ -105,6 +105,9 @@
     if (document.hidden && timer) {
       window.clearTimeout(timer);
       timer = null;
+      // If we cancel during a fade, the flash promise chain is abandoned and
+      // never removes is-flashing; clear it so the slide isn't left mid-fade.
+      root.classList.remove("is-flashing");
     } else if (!document.hidden && !timer && !reducedMotion) {
       timer = window.setTimeout(loop, holdMs);
     }

--- a/httpdocs/js/home.js
+++ b/httpdocs/js/home.js
@@ -40,7 +40,7 @@
       var bestId = null;
       var bestRatio = 0;
       navSections.forEach(function (item) {
-        var ratio = parseFloat(item.el.dataset.navVisible || "0", 10);
+        var ratio = parseFloat(item.el.dataset.navVisible || "0");
         if (ratio > bestRatio) {
           bestRatio = ratio;
           bestId = item.id;


### PR DESCRIPTION
Low-severity robustness fixes in the new widget scripts (`httpdocs/js/`).

### W1 — `hero-display.js`: `is-flashing` can get stuck mid-fade
A single `timer` variable backs both the fade and the hold `setTimeout`. If `visibilitychange` fires while `document.hidden` during a fade, `clearTimeout(timer)` abandons the fade's `resolve`, so the `.then` chain never runs and `is-flashing` is never removed — the slide is left mid-fade until the next visible `loop` self-heals it. Now removes `is-flashing` when cancelling on hide so the visual state can't get stuck.

### W2 — `battery-widget.js`: unguarded `querySelector` results
`render()` and the event wiring dereference ~14 `querySelector` results, but only `root` and `elEspWarn` were null-checked. If `#battery-widget` exists but a child like `[data-batt-range]` is missing, `elRange.addEventListener(...)` throws and aborts the whole IIFE. Added a single early-bail guard for the required elements (mirrors the existing `if (!root) return`), keeping `elEspWarn` as a genuinely optional null-check.

### W3 — `home.js`: `parseFloat` given a radix
`parseFloat(item.el.dataset.navVisible || "0", 10)` — `parseFloat` takes no radix argument; the `10` is silently ignored (likely a copy/paste from `parseInt`). Dropped it. Harmless, but removes the misleading argument.

### Verification
Static change; verified by inspection and brace/paren/bracket balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TgdTn28d19EQCszckW7yb