### PR TITLE
Don't trust getAvailability on iOS and reconcile deployed device-filter logic

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -405,13 +405,18 @@ class OpenDisplayBLE {
 
   buildRequestDeviceOptionAttempts(prefix) {
     const prefixes = prefix.split(',').map(p => p.trim()).filter(p => p);
-    const nameFilters = (prefixes.length ? prefixes : ['OD']).map(p => ({ namePrefix: p }));
+    const effectivePrefixes = prefixes.length ? prefixes : ['OD'];
+    const nameFilters = effectivePrefixes.map(p => ({ namePrefix: p }));
     const serviceUuid = this.serviceUUID;
     const mfgFilter = {
       manufacturerData: [{ companyIdentifier: OPENDISPLAY_MSD_COMPANY_ID }]
     };
     const serviceFilter = { services: [serviceUuid] };
-    const discoveryFilters = [mfgFilter, serviceFilter, ...nameFilters];
+    // Web Bluetooth ORs separate filter objects. MSD/service-only entries match
+    // every OpenDisplay device, so a specific name prefix must not share the
+    // filters array with them — only the default "OD" scan uses broad OR discovery.
+    const isBroadDiscovery =
+      effectivePrefixes.length === 1 && effectivePrefixes[0] === 'OD';
 
     if (this.usesUnfilteredBleScan()) {
       // acceptAllDevices lets the user *select* any device, but GATT services
@@ -424,17 +429,30 @@ class OpenDisplayBLE {
       }];
     }
 
+    if (isBroadDiscovery) {
+      return [
+        {
+          optionalServices: [serviceUuid],
+          filters: [mfgFilter, serviceFilter, ...nameFilters]
+        },
+        {
+          // Fallback: some older Chromium builds reject a manufacturerData filter
+          // with a "payload ... parse" error. Retry with name/service-only filters.
+          optionalServices: [serviceUuid],
+          filters: [serviceFilter, ...nameFilters]
+        }
+      ];
+    }
+
     return [
       {
         optionalServices: [serviceUuid],
-        filters: discoveryFilters
+        filters: nameFilters
       },
       {
-        // Fallback: some older Chromium builds reject a manufacturerData filter
-        // with a "payload ... parse" error. Retry with name/service-only filters
-        // (this is the attempt the retry loop in requestBleDevice falls back to).
+        // AND service + name within each filter (still OR across comma-separated prefixes).
         optionalServices: [serviceUuid],
-        filters: [serviceFilter, ...nameFilters]
+        filters: nameFilters.map(nf => ({ ...serviceFilter, ...nf }))
       }
     ];
   }
@@ -4335,7 +4353,11 @@ const OpenDisplayBrowser = {
       alert(this.webBluetoothUnsupportedMessage());
       return false;
     }
-    if (navigator.bluetooth.getAvailability) {
+    // On iOS/Bluefy getAvailability() is unreliable — it can resolve false even
+    // when Bluetooth works, which would wrongly block the device selector from
+    // ever opening. Treat it as inconclusive there and go straight to
+    // requestDevice; the picker itself surfaces any real adapter problem.
+    if (!this.isIOS() && !this.isBluefy() && navigator.bluetooth.getAvailability) {
       try {
         const available = await navigator.bluetooth.getAvailability();
         if (!available) {


### PR DESCRIPTION
Two related device-selection changes in `httpdocs/js/ble-common.js`.

## a) Skip the getAvailability gate on iOS/Bluefy
`OpenDisplayBrowser.ensureWebBluetoothAvailable()` aborted the entire connect flow (alert + `return false`) whenever `navigator.bluetooth.getAvailability()` resolved false. On iOS/Bluefy that signal is unreliable — a user reported that with Bluefys developer mode off the device selector never even opened, which is exactly what this gate would cause. The change treats `getAvailability` as inconclusive on iOS/Bluefy (`this.isIOS() || this.isBluefy()`) and goes straight to `requestDevice`, where the native picker surfaces any real adapter problem. Non-iOS behavior is unchanged.

## b) Reconcile device-filter logic with production
The production server at opendisplay.org has been serving a hand-edited `ble-common.js` whose improved `buildRequestDeviceOptionAttempts` was never committed. This ports that logic verbatim so the repo matches whats deployed. It introduces an `isBroadDiscovery` flag so that:
- The default `OD` scan keeps broad OR discovery (manufacturerData + service + name filters, with a name/service-only fallback for older Chromium builds that reject a manufacturerData filter).
- A **specific** name-prefix scan (e.g. `ODX`, or a comma list) uses **name filters only**, with an AND-ed service+name fallback attempt — instead of OR-ing in the broad manufacturerData/service filters that match *every* OpenDisplay device and would defeat the point of scanning for a specific prefix.

To be clear: this filter logic is already live on opendisplay.org today; this PR simply reconciles the repository with production so the committed source matches what users are actually running.

## Verification
- `node --check httpdocs/js/ble-common.js` passes.
- The `buildRequestDeviceOptionAttempts` region now matches the deployed file byte-for-byte (`diff` of the region is empty).
- A throwaway Node harness confirms the branch behavior: `OD` yields the broad manufacturerData+service+name filter set; a specific `ODX` yields name-only filters plus an AND-ed `{service, namePrefix}` fallback and no standalone broad manufacturerData/service filter; a comma list `ODA,ODB` yields two name-prefix filters on the specific path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEs4tsAWupf2DXFM4faECC