### PR TITLE
Fix BLE connection on iOS/Bluefy: gesture, feature detection, device filtering

### DIFF
--- a/httpdocs/designer/index.html
+++ b/httpdocs/designer/index.html
@@ -3942,6 +3942,13 @@
         connectButton.textContent = 'Connect';
         bleLib.disconnect();
       } else {
+        void (async () => {
+        // Feature-detect before touching navigator.bluetooth so unsupported
+        // browsers (iOS Safari, etc.) get the "use Bluefy" prompt instead of a
+        // raw TypeError.
+        if (!window.OpenDisplayBrowser || !(await window.OpenDisplayBrowser.ensureWebBluetoothAvailable())) {
+          return;
+        }
         const deviceFilter = document.getElementById('bleDeviceFilter').value.trim();
         if (!deviceFilter) {
           addBLELog("Error: Device filter needed.", 'error');
@@ -3993,6 +4000,7 @@
             setBLEStatus(`Error: ${error.message}`, false);
           }
         });
+        })();
       }
     }
 

--- a/httpdocs/firmware/battery/index.html
+++ b/httpdocs/firmware/battery/index.html
@@ -260,6 +260,12 @@ function preConnect() {
     document.getElementById("connectbutton").innerHTML = 'Connect';
     bleLib.disconnect();
   } else {
+    void (async () => {
+    // Feature-detect before touching navigator.bluetooth so unsupported browsers
+    // (iOS Safari, etc.) get the "use Bluefy" prompt instead of a raw TypeError.
+    if (!window.OpenDisplayBrowser || !(await window.OpenDisplayBrowser.ensureWebBluetoothAvailable())) {
+      return;
+    }
     const namePrefix = document.getElementById('namePrefix').value.trim();
     if (!namePrefix) {
       addLog("Error: Device filter needed.", 'error');
@@ -309,6 +315,7 @@ function preConnect() {
         handleError(error);
       }
     });
+    })();
   }
 }
 

--- a/httpdocs/firmware/display/index.html
+++ b/httpdocs/firmware/display/index.html
@@ -2523,13 +2523,20 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
                 }
             }
             
-            // Check for auto-connect parameter
+            // Check for auto-connect parameter.
+            // Web Bluetooth's requestDevice() requires a live user gesture, so we
+            // cannot open the chooser from a page-load timer — that only works
+            // with an experimental browser flag ("developer mode") and otherwise
+            // silently fails. Instead, pre-fill the filter (done above) and prompt
+            // the user to tap Connect so the chooser opens inside a real gesture.
             const autoConnect = getUrlParameter('connect') === 'true' || getUrlParameter('auto') === 'true';
             if (autoConnect && filterParam) {
-                addLog("Auto-connecting...", 'info');
-                setTimeout(() => {
-                    preConnect();
-                }, 500);
+                addLog("Ready to connect — tap the Connect button to pair your display.", 'info');
+                setStatus("Tap Connect to pair", false);
+                const connectBtn = document.getElementById('connectbutton');
+                if (connectBtn) {
+                    try { connectBtn.focus(); } catch (e) {}
+                }
             }
         }
         

--- a/httpdocs/firmware/toolbox/index.html
+++ b/httpdocs/firmware/toolbox/index.html
@@ -2113,7 +2113,7 @@ async function startAutoInstall() {
     alert('Auto-install failed: ' + error.message);
   }
 }
-function connectToBleDevice() {
+function connectToBleDevice(useCachedDevice = false) {
   return new Promise((resolve, reject) => {
     void ensureWebBluetoothAvailable().then((ok) => {
     if (!ok) {
@@ -2161,10 +2161,14 @@ function connectToBleDevice() {
         }
       });
     }
-    addLog("Requesting device with filters: " + namePrefix);
-    setStatus("Requesting device...");
-    document.getElementById("connectbutton").innerHTML = 'Scanning...';
-    bleLib.connect(namePrefix)
+    if (useCachedDevice) {
+      addLog("Reconnecting to previously selected device...");
+    } else {
+      addLog("Requesting device with filters: " + namePrefix);
+    }
+    setStatus(useCachedDevice ? "Reconnecting..." : "Requesting device...");
+    document.getElementById("connectbutton").innerHTML = useCachedDevice ? 'Reconnecting...' : 'Scanning...';
+    bleLib.connect(namePrefix, { useCachedDevice })
       .then(() => {
         // onConnect callback will call resolve()
       })
@@ -3094,9 +3098,12 @@ async function waitForDeviceReboot(maxWaitTime = 65000, retryInterval = 5000) {
       addLog(`Attempting to reconnect (waited ${elapsed}s)...`, 'info');
       updateProgressBar(92 + Math.min(5, Math.floor(elapsed / 10)), `Waiting for reboot (${elapsed}s)...`);
       
-      // Try to connect
-      await connectToBleDevice();
-      
+      // Reconnect via the cached device (device.gatt.connect()) rather than a
+      // fresh requestDevice() chooser. We are inside a timer loop with no user
+      // gesture, so a chooser would be blocked off the experimental flag and
+      // would fail on iOS/Bluefy.
+      await connectToBleDevice(true);
+
       // If we get here, connection succeeded
       addLog('Device reconnected after reboot!', 'success');
       await delay(2000); // Wait for connection to stabilize

--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -495,34 +495,64 @@ class OpenDisplayBLE {
 
   /**
    * Request device and connect
+   *
+   * @param {string|null} deviceNamePrefix - name filter for the chooser
+   * @param {object} [options]
+   * @param {boolean} [options.useCachedDevice] - reconnect to the previously
+   *   selected device via device.gatt.connect() instead of opening a new
+   *   chooser. requestDevice() needs a live user gesture (and is blocked off the
+   *   experimental flag), so this cached path is the only reliable way to
+   *   reconnect after a device reboot — and it is iOS/Bluefy-safe.
    */
-  async connect(deviceNamePrefix = null) {
+  async connect(deviceNamePrefix = null, options = {}) {
     if (this.isConnected && this.device && this.device.gatt && this.device.gatt.connected) {
       this.log('Already connected', 'info');
       return true;
     }
-    
+
+    // Gesture-free reconnect to the device the user already chose.
+    if (options.useCachedDevice && this.device) {
+      try {
+        this.log('Reconnecting to previously selected device...', 'info');
+        this.autoReconnectEnabled = true;
+        // addEventListener with the same bound reference is a no-op if already
+        // attached, so this is safe whether or not disconnect() removed it.
+        this.device.addEventListener('gattserverdisconnected', this._onDisconnect);
+        return await this.connectToGATT();
+      } catch (error) {
+        this.handleError(error);
+        throw error;
+      }
+    }
+
     const prefix = deviceNamePrefix || this.deviceNamePrefix;
     if (!prefix) {
       throw new Error('Device name prefix required');
     }
-    
+
     try {
       this.autoReconnectEnabled = true;
       this.setStatus('Requesting device...', false);
-      
+
       this.device = await this.requestBleDevice(prefix);
       this.log(`Found: ${this.device.name || 'Unknown device'} (${this.device.id})`, 'success');
       this.setStatus(`Found ${this.device.name || 'device'}`, false);
-      
+
       this.device.addEventListener('gattserverdisconnected', this._onDisconnect);
-      
+
       return await this.connectToGATT();
     } catch (error) {
       if (error.name === 'NotFoundError' || error.name === 'AbortError') {
         this.log('No device selected/found', 'error');
         this.setStatus('No device selected', false);
         throw new Error('Device selection cancelled or not found');
+      }
+      if (error.name === 'SecurityError') {
+        // A SecurityError here almost always means requestDevice() was called
+        // without a live user gesture (e.g. from a timer or after an await).
+        // Without a message this just looks like nothing happened.
+        this.log('Bluetooth chooser was blocked — tap Connect to select a device.', 'error');
+        this.setStatus('Tap Connect to choose a device', false);
       }
       this.handleError(error);
       throw error;

--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -398,18 +398,26 @@ class OpenDisplayBLE {
   }
   
   /**
-   * iOS WebKit (Bluefy) cannot reliably match name/service/manufacturer filters
-   * against ESP/nRF advertising packets — show every nearby device instead.
+   * Bluefy's BLE engine is the only practical Web Bluetooth on iOS (mobile
+   * Safari has none, so it never reaches this code). It matches name and
+   * manufacturer-data filters against our advertising packets, but not
+   * service-UUID-only filters (ESP32 drops the 128-bit UUID from the 31-byte
+   * primary packet), so its requestDevice attempts are built specially.
    */
-  usesUnfilteredBleScan() {
+  usesBluefyBleEngine() {
     return !!(typeof window !== 'undefined'
       && window.OpenDisplayBrowser
-      && window.OpenDisplayBrowser.isIOS()
+      && window.OpenDisplayBrowser.isBluefy()
       && window.OpenDisplayBrowser.isWebBluetoothSupported());
   }
 
+  // Back-compat aliases for the previous names.
+  usesUnfilteredBleScan() {
+    return this.usesBluefyBleEngine();
+  }
+
   usesWebKitBleRequestDeviceWorkaround() {
-    return this.usesUnfilteredBleScan();
+    return this.usesBluefyBleEngine();
   }
 
   buildRequestDeviceOptionAttempts(prefix) {
@@ -427,15 +435,26 @@ class OpenDisplayBLE {
     const isBroadDiscovery =
       effectivePrefixes.length === 1 && effectivePrefixes[0] === 'OD';
 
-    if (this.usesUnfilteredBleScan()) {
-      // acceptAllDevices lets the user *select* any device, but GATT services
-      // are still only accessible if declared in optionalServices — without it,
-      // getPrimaryService(this.serviceUUID) rejects with a SecurityError right
-      // after selection.
-      return [{
-        acceptAllDevices: true,
-        optionalServices: [serviceUuid]
-      }];
+    if (this.usesBluefyBleEngine()) {
+      // A device MUST match the (user-configurable, default "OD") name prefix —
+      // Bluefy matches namePrefix against the advertised Complete Local Name.
+      // We deliberately do NOT OR in the manufacturer-id / service filters here:
+      // those match every OpenDisplay device and would defeat a specific prefix,
+      // putting unrelated displays back in the chooser. optionalServices is
+      // required in every attempt or getPrimaryService() rejects with a
+      // SecurityError right after selection.
+      return [
+        {
+          optionalServices: [serviceUuid],
+          filters: nameFilters
+        },
+        {
+          // Escape hatch: only reached if Bluefy rejects the filter set
+          // outright (validation/not-supported), never on an empty chooser.
+          acceptAllDevices: true,
+          optionalServices: [serviceUuid]
+        }
+      ];
     }
 
     if (isBroadDiscovery) {
@@ -471,6 +490,19 @@ class OpenDisplayBLE {
     return msg.includes('payload') && msg.includes('pars');
   }
 
+  // A rejection from requestDevice() caused by the *options* (an unsupported or
+  // malformed filter), not by the user or the scan. These are thrown during
+  // option validation — before the chooser opens and before the user gesture is
+  // consumed — so it is safe to advance to a simpler fallback attempt. A user
+  // cancel / empty chooser is NotFoundError/AbortError and must NOT match here,
+  // or we would re-prompt (and burn the gesture) in a loop.
+  isRequestDeviceOptionsError(error) {
+    if (!error) return false;
+    if (error.name === 'TypeError' || error.name === 'NotSupportedError') return true;
+    const msg = (error.message || '').toLowerCase();
+    return msg.includes('filter') || msg.includes('not supported') || msg.includes('manufacturerdata');
+  }
+
   async requestBleDevice(prefix) {
     const attempts = this.buildRequestDeviceOptionAttempts(prefix);
     let lastError = null;
@@ -484,7 +516,8 @@ class OpenDisplayBLE {
         return await navigator.bluetooth.requestDevice(deviceOptions);
       } catch (error) {
         lastError = error;
-        if (!this.isRequestDevicePayloadError(error) || i === attempts.length - 1) {
+        const canRetry = this.isRequestDevicePayloadError(error) || this.isRequestDeviceOptionsError(error);
+        if (!canRetry || i === attempts.length - 1) {
           throw error;
         }
         this.log(`requestDevice attempt ${i + 1} failed (${error.message}), retrying...`, 'warning');


### PR DESCRIPTION
## Summary
Fixes the reported "the BLE connection dialog won't launch unless the browser is in developer mode" blocker, plus related iOS/Bluefy robustness gaps, and makes the device chooser actually filter to OpenDisplay devices on Bluefy.

`navigator.bluetooth.requestDevice()` requires a **live user gesture**. Calling it from a timer or after an `await` throws `SecurityError`, and off the experimental Web Platform flag ("developer mode") it silently does nothing. Two code paths triggered this, two pages threw a raw `TypeError` on browsers without Web Bluetooth, and on iOS the chooser was showing *every* nearby BLE device.

## Changes
- **display** — replace the page-load `setTimeout(preConnect)` auto-connect (`?connect=true`/`?auto=true`) with a pre-filled filter + a "tap Connect to pair" prompt, so the chooser opens inside a real gesture.
- **toolbox** — after a device reboot, reconnect via the **cached device** (`device.gatt.connect()`) instead of a fresh `requestDevice()` chooser. Adds a `useCachedDevice` option to `OpenDisplayBLE.connect()`; the cached path is gesture-free and iOS/Bluefy-safe.
- **battery, designer** — gate `connect()` behind `OpenDisplayBrowser.ensureWebBluetoothAvailable()` so unsupported browsers get the "use Bluefy" prompt instead of a `TypeError` (matches the display page).
- **ble-common (SecurityError)** — surface a clear message on `SecurityError` in `connect()` so a blocked chooser no longer appears to do nothing.
- **ble-common (device filtering on Bluefy)** — the chooser previously used `acceptAllDevices` for *any* iOS browser, listing every nearby device. The firmware advertises the device name (`OD`-prefix) in the primary packet, and Bluefy matches `namePrefix` filters fine. Now:
  - the workaround is gated on **Bluefy's engine specifically** (`isBluefy()`), not any iOS browser (mobile Safari has no Web Bluetooth and never reaches this code);
  - on Bluefy the device **must match the user-configurable name prefix** (default `OD`) via a `namePrefix` filter, keeping `optionalServices` so GATT access survives selection. Manufacturer-id / service filters are intentionally *not* OR'd in — they match every OpenDisplay device and would defeat a specific prefix;
  - falls back to `acceptAllDevices` only if Bluefy rejects the filter set outright (option-validation `TypeError`/`NotSupportedError`), never on user-cancel.

This builds on the BLE work already merged (canonical UUIDs, ack-based config writes, listener-leak fix); those findings are already resolved upstream and are not re-touched here.

## Testing notes
- Desktop Chrome (flag OFF): `?connect=true` links now show a tap-to-connect prompt rather than silently failing; the Connect button opens the chooser. Non-Bluefy filter paths unchanged.
- iOS/Bluefy: battery & designer show the support prompt instead of a `TypeError`; the chooser now lists only `OD…` devices (or only those matching a specific typed/`?filter=` prefix); reboot-reconnect no longer pops a second chooser.
- Reconnect after a config write + device reboot succeeds via the cached device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)