### PR TITLE
Add writeValueWithResponse fallback for iOS/Bluefy

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -828,7 +828,7 @@ class OpenDisplayBLE {
     let retries = 0;
     while (retries <= this.gattMaxRetries) {
       try {
-        await this.characteristic.writeValueWithoutResponse(commandToSend);
+        await this.writeCommandValue(commandToSend);
         return;
       } catch (error) {
         if (error.name === 'NetworkError' && error.message.includes('GATT operation') && retries < this.gattMaxRetries) {
@@ -840,6 +840,48 @@ class OpenDisplayBLE {
         }
       }
     }
+  }
+
+  /**
+   * Write a value to the command characteristic.
+   *
+   * Prefers writeValueWithoutResponse() for throughput, but some engines —
+   * notably WebKit/Bluefy on iOS — don't reliably support it, and a
+   * characteristic may only advertise the "write" (with response) property.
+   * Fall back to writeValueWithResponse() (and remember the choice so we don't
+   * keep retrying the unsupported path). The firmware uses application-level
+   * acks (0x41/0x42), so the ATT write type does not change protocol behaviour.
+   */
+  async writeCommandValue(data) {
+    const props = this.characteristic.properties;
+    const canWriteWithout =
+      !this._writeWithoutResponseUnsupported &&
+      typeof this.characteristic.writeValueWithoutResponse === 'function' &&
+      (!props || props.writeWithoutResponse !== false);
+
+    if (canWriteWithout) {
+      try {
+        await this.characteristic.writeValueWithoutResponse(data);
+        return;
+      } catch (error) {
+        // Only fall back on "not supported"; propagate transient errors
+        // (e.g. NetworkError) so the caller's retry loop can handle them.
+        const canFallback = typeof this.characteristic.writeValueWithResponse === 'function';
+        if (error && error.name === 'NotSupportedError' && canFallback) {
+          this._writeWithoutResponseUnsupported = true;
+          this.log('writeValueWithoutResponse unsupported; using writeValueWithResponse', 'warning');
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (typeof this.characteristic.writeValueWithResponse === 'function') {
+      await this.characteristic.writeValueWithResponse(data);
+      return;
+    }
+    // Legacy engines expose only writeValue().
+    await this.characteristic.writeValue(data);
   }
   
   /**


### PR DESCRIPTION
## Summary
Every BLE command is sent via `characteristic.writeValueWithoutResponse()` with no fallback. On WebKit/Bluefy (iOS) this is flaky, and a characteristic that only advertises the **write (with response)** property makes the call throw `NotSupportedError`. The existing retry loop only catches `NetworkError`, so the write threw straight out — the likely cause of the "pairs, then fails on the first command" reports on iOS.

## Change
Route command writes through a new `writeCommandValue()` that:
1. prefers `writeValueWithoutResponse()` for throughput,
2. falls back to `writeValueWithResponse()` when the fast path is unsupported (`NotSupportedError`, or the characteristic doesn't advertise `writeWithoutResponse`), remembering the choice so it doesn't keep retrying the unsupported path,
3. drops to legacy `writeValue()` as a last resort.

The firmware acknowledges writes at the application layer (`0x41`/`0x42`), so switching the ATT write type does not change protocol behaviour — it only adds flow control on engines that need it. Behaviour on Chrome/Android (which support write-without-response) is unchanged.

## Testing notes
- Desktop Chrome: writes still use write-without-response; config read/write round-trips unchanged.
- iOS/Bluefy: a characteristic without `writeWithoutResponse` now succeeds via the with-response path instead of throwing on the first command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)