### PR TITLE
docs: warn about partial-refresh whiteout outside the region on some panels

### DIFF
--- a/httpdocs/protocol/ble-flow.html
+++ b/httpdocs/protocol/ble-flow.html
@@ -782,6 +782,21 @@ payload is exactly the same blob as a single BLE <em>write</em> to the OpenDispl
       instead of the full frame. Requires <code>partial_update_support: 1</code> in Flex config (main reference firmware only; 
       see <a href="reference-firmware-variants.html" style="color: var(--accent);">firmware variants</a>).
     </p>
+    <div class="flow-step" style="border-left: 4px solid #e0a800;">
+      <h4>&#9888;&#65039; Known firmware issue: content outside the region is erased on some panels</h4>
+      <p>
+        At partial start the reference firmware re-initializes the panel and fills both controller RAM planes
+        white before writing the region. On panels whose partial waveform actively drives pixels whose old and
+        new RAM values are equal (confirmed on EP426 / Seeed EN05), everything <strong>outside</strong> the
+        rectangle is erased to white &mdash; while every protocol response still ACKs, so clients cannot detect
+        it. Until per-panel signaling exists (see
+        <a href="https://github.com/OpenDisplay/Firmware/issues/80" style="color: var(--accent);">Firmware issue #80</a>),
+        the safe pattern on affected panels is a <strong>full-frame partial</strong>: send
+        <code>x=0, y=0, w=panel_width, h=panel_height</code> with both full planes. This still refreshes with
+        the flicker-free partial waveform (hardware-verified) at the cost of a full-frame transfer, which
+        zlib-compresses well for typical content.
+      </p>
+    </div>
     <div class="flow-step">
       <h4>Start: <code>0x0076</code></h4>
       <div class="code-block">

--- a/httpdocs/protocol/ble-flow.html
+++ b/httpdocs/protocol/ble-flow.html
@@ -779,22 +779,25 @@ payload is exactly the same blob as a single BLE <em>write</em> to the OpenDispl
     <h3 id="partial-update">3. Partial region update (<code>0x0076</code>)</h3>
     <p class="intro-text">
       For 1 bpp B/W panels that support differential partial refresh, the client can update a rectangular region 
-      instead of the full frame. Requires <code>partial_update_support: 1</code> in Flex config (main reference firmware only; 
+      instead of the full frame. Requires <code>partial_update_support: 1</code> (region updates) or <code>2</code> (full-frame stream required) in Flex config (main reference firmware only; 
       see <a href="reference-firmware-variants.html" style="color: var(--accent);">firmware variants</a>).
     </p>
-    <div class="flow-step" style="border-left: 4px solid #e0a800;">
-      <h4>&#9888;&#65039; Known firmware issue: content outside the region is erased on some panels</h4>
+    <div class="flow-step">
+      <h4>Region strategy: check <code>partial_update_support</code></h4>
       <p>
-        At partial start the reference firmware re-initializes the panel and fills both controller RAM planes
-        white before writing the region. On panels whose partial waveform actively drives pixels whose old and
-        new RAM values are equal (confirmed on EP426 / Seeed EN05), everything <strong>outside</strong> the
-        rectangle is erased to white &mdash; while every protocol response still ACKs, so clients cannot detect
-        it. Until per-panel signaling exists (see
-        <a href="https://github.com/OpenDisplay/Firmware/issues/80" style="color: var(--accent);">Firmware issue #80</a>),
-        the safe pattern on affected panels is a <strong>full-frame partial</strong>: send
-        <code>x=0, y=0, w=panel_width, h=panel_height</code> with both full planes. This still refreshes with
-        the flicker-free partial waveform (hardware-verified) at the cost of a full-frame transfer, which
-        zlib-compresses well for typical content.
+        The display config enum tells the client which region strategy the panel supports:
+        <code>1</code> = arbitrary rectangular regions; <code>2</code> = partial updates supported but the
+        stream <strong>must cover the full panel</strong> (<code>x=0, y=0, w=panel_width, h=panel_height</code>,
+        both planes). Value <code>2</code> exists because the firmware white-fills both controller RAM planes at
+        partial start, and on some panels (e.g. EP426 / Seeed EN05) the partial waveform erases everything the
+        stream does not cover &mdash; while every protocol response still ACKs. A full-frame partial still
+        refreshes with the flicker-free partial waveform; the stream zlib-compresses well for typical content.
+        Background: <a href="https://github.com/OpenDisplay/Firmware/issues/80" style="color: var(--accent);">Firmware issue #80</a>.
+      </p>
+      <p style="color: var(--muted-foreground);">
+        &#9888;&#65039; Device configs written before this enum value existed may report <code>1</code> on
+        affected panels. When targeting unknown devices, treat region updates on such panels with care or
+        default to full-frame streams.
       </p>
     </div>
     <div class="flow-step">


### PR DESCRIPTION
Adds a warning box to the 0x76 partial-update section of the BLE protocol docs.

The reference firmware white-fills both controller RAM planes at partial START; on panels whose partial waveform actively drives equal old/new pixels (hardware-confirmed on EP426 / Seeed EN05, camera evidence in OpenDisplay/Firmware#80) everything outside the rectangle is erased to white while every protocol response ACKs — a client implementing this page as written ships the bug undetectably. The box documents the hardware-verified full-frame-partial workaround until per-panel signaling exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)