### PR TITLE
fix: row-pad BWR/BWY bitplanes to match firmware

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -3489,11 +3489,17 @@ class OpenDisplayBLE {
             bitPosition = 7;
           }
         }
-      }
-      
-      if (bitPosition !== 7) {
-        byteDataPlane1.push(currentByte1);
-        byteDataPlane2.push(currentByte2);
+        // Row-pad each plane to a byte boundary (matches np.packbits(axis=1) on the
+        // Python sender and the firmware's row-padded two-plane BWR/BWY path, PR #82).
+        // Without this, panels whose width isn't a multiple of 8 (e.g. 122-wide EP213)
+        // would carry pixels of the next row into a shared byte (flat packing).
+        if (bitPosition !== 7) {
+          byteDataPlane1.push(currentByte1);
+          byteDataPlane2.push(currentByte2);
+          currentByte1 = 0;
+          currentByte2 = 0;
+          bitPosition = 7;
+        }
       }
       byteData.push(...byteDataPlane1);
       byteData.push(...byteDataPlane2);


### PR DESCRIPTION
## Problem

The Web Bluetooth encoder in `httpdocs/js/ble-common.js` **flat-packs** the BWR/BWY (3-colour black/white + red or yellow) two-plane byte stream across row boundaries. In the `colorScheme === 1 || colorScheme === 2` branch, `bitPosition` was not reset at the end of each row, so a partial final byte of row *y* carried pixels of row *y+1*.

On panels whose width is not a multiple of 8 (e.g. the 122-wide EP213) this makes the website's byte stream shorter than the firmware now expects, and the direct-display upload is rejected.

The firmware just landed row-padded two-plane packing for BWR/BWY in **OpenDisplay/Firmware#82**, matching the Python sender (`np.packbits(axis=1)`) and the existing GRAY4 path. This PR is the **web-tool counterpart** to that firmware change: https://github.com/OpenDisplay/Firmware/pull/82

## Fix

Flush the partial byte at the **end of each row** so every row starts byte-aligned (row-padded), plane0 = black/white then plane1 = accent. The previous post-loop flush is folded into the per-row flush (it was always a no-op once rows flush). Only BWR/BWY (colorScheme 1 & 2) is touched — mono (1bpp), 2bpp and 4bpp are flat by firmware design and are left unchanged.

The uncompressed-size prefix sent to firmware (`sendCanvasToDisplay`) is derived from `byteData.length`, which now grows correctly with the added row padding; there is no separate flat `width*height/8` computation to update.

## Testing

Static-site JS (no build). `node --check httpdocs/js/ble-common.js` passes.

A throwaway Node harness exercising the encoder loop on a small odd-width image confirms row padding:

**3 × 2, all-white:**
```
NEW row-padded plane0: [0b11100000, 0b11100000]  plane1: [0b00000000, 0b00000000]  total len: 4
OLD flat       plane0: [0b11111100]              plane1: [0b00000000]              total len: 2
```
Each row is now its own padded byte (`0b11100000`) instead of two rows sharing one byte.

**8 × 2, all-white (width divisible by 8 — must be unchanged):**
```
NEW plane0: [0b11111111, 0b11111111]  total len: 4
OLD plane0: [0b11111111, 0b11111111]  total len: 4   identical: true
```

## Still needs

A real-hardware smoke test: a direct BWR upload to an odd-width panel (e.g. EP213, width 122) confirming firmware accepts the row-padded stream and renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR