### PR TITLE
fix: zero length bytes in config CRC read-back to match toolbox/firmware

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -2800,7 +2800,24 @@ class OpenDisplayBLE {
     }
     return crc & 0xFFFF;
   }
-  
+
+  /**
+   * CRC-16/CCITT-FALSE over an outer config container body, with the first
+   * two (length) bytes treated as zero. Matches the toolbox writer and the
+   * firmware's config_toolbox_outer_crc16: the toolbox computes the CRC while
+   * the length bytes are still 0,0 and writes the real length afterward, so
+   * read-back must zero those bytes to agree. Advisory only.
+   */
+  crc16ccittOuter(body) {
+    const b = body instanceof Uint8Array ? body : new Uint8Array(body);
+    if (b.length < 2) return this.crc16ccitt(b);
+    const tmp = new Uint8Array(b.length);
+    tmp[0] = 0;
+    tmp[1] = 0;
+    tmp.set(b.subarray(2), 2);
+    return this.crc16ccitt(tmp);
+  }
+
   /**
    * Convert number to little-endian byte array
    */
@@ -2934,7 +2951,7 @@ class OpenDisplayBLE {
     
     const crcGiven = view[view.length - 2] | (view[view.length - 1] << 8);
     const body = view.slice(0, view.length - 2);
-    const crcCheck = this.crc16ccitt(body);
+    const crcCheck = this.crc16ccittOuter(body);
     
     const result = {
       length: len,

--- a/httpdocs/protocol/flex-standard.html
+++ b/httpdocs/protocol/flex-standard.html
@@ -108,7 +108,8 @@
     </p>
     <p class="intro-text">
       Configuration is transferred as an <strong>outer packet</strong>: 2-byte length, 1-byte version, a sequence of 
-      inner packets, then CRC16-CCITT. Each inner packet has a sequential <code>number</code>, a type <code>id</code>, 
+      inner packets, then a 2-byte CRC. The CRC is CRC-16/CCITT-FALSE (init 0xFFFF, poly 0x1021) computed over the
+      container excluding the trailing CRC, with the 2 length bytes treated as zero. Each inner packet has a sequential <code>number</code>, a type <code>id</code>,
       and a typed payload. Full field definitions: <a href="yaml-config.html" style="color: var(--accent);">YAML configuration reference</a>.
     </p>
     <p class="intro-text">

--- a/httpdocs/protocol/yaml-config.html
+++ b/httpdocs/protocol/yaml-config.html
@@ -386,7 +386,7 @@ table code {
       <tr>
         <td><code>crc</code></td>
         <td>2 bytes</td>
-        <td>CRC16-CCITT checksum (excluding CRC field)</td>
+        <td>CRC-16/CCITT-FALSE (init 0xFFFF, poly 0x1021) over the container excluding the trailing CRC field, with the 2 length bytes treated as zero</td>
       </tr>
     </table>
 


### PR DESCRIPTION
## Problem (MJ-11)

`parseConfigBytes` in `httpdocs/js/ble-common.js` computed the config-container CRC over the raw container body **without zeroing the first two (length) bytes**. As a result, its read-back CRC indicator reported a false "mismatch" for every real config.

This is the website disagreeing with itself and with firmware. The config-container CRC is standardized on **CRC-16/CCITT-FALSE** (init `0xFFFF`, poly `0x1021`, MSB-first, no reflection/XOR) computed over `[byte0, byte1, version, ...packets]` with the **first two (length) bytes forced to zero**, excluding the trailing 2 CRC bytes:

- The toolbox **write** path CRCs while the length bytes are still `0,0` (the real length is written afterward).
- The toolbox **read** path (`crc16ccittOpenDisplayOuter`) already zeroes the first two bytes.
- Firmware validates the same way via `config_toolbox_outer_crc16`.

Only the website read-back was out of step.

## Fix

- Add `crc16ccittOuter(body)` to `OpenDisplayBLE`: copies the body with bytes 0–1 zeroed, then calls the existing `crc16ccitt` primitive (unchanged). Use it in `parseConfigBytes`.
- The two other consumers the audit flagged (`httpdocs/firmware/display/index.html`, `httpdocs/designer/index.html`) do not compute the config CRC themselves — they call `parseConfigBytes` — so they are fixed transitively; no direct edits needed.
- Clarify the protocol docs (`yaml-config.html`, `flex-standard.html`) to state the canonical CRC precisely: CRC-16/CCITT-FALSE over the container excluding the trailing CRC, with the 2 length bytes treated as zero.

## Testing

Node harness replicating the new zeroing logic + `crc16ccitt` against ground-truth vectors:

```
PASS  input=000001                                 got=0xDCBD  exp=0xDCBD
PASS  input=2a0001aabb                             got=0xC239  exp=0xC239
PASS  input=42000100010000000000000000000000000000 got=0x0D7F  exp=0x0D7F
PASS  input=00000100010000000000000000000000000000 got=0x0D7F  exp=0x0D7F
PASS  length-invariance: real-length 0x0D7F === zeroed-length 0x0D7F
```

The last two prove length-zeroing: a config with real length bytes (`42 00 …`) and the same config with zeroed length bytes (`00 00 …`) now produce the **same** read-back CRC. `node --check httpdocs/js/ble-common.js` passes.

## Advisory only

This changes only the advisory read-back indicator. No rejection is added; `crc16ccitt` itself is untouched; the toolbox write path and `crc16ccittOpenDisplayOuter` are untouched.

Part of the config-CRC CCITT standardization (MJ-7); companion changes in OpenDisplay/py-opendisplay and OpenDisplay/Firmware. Cross-links to be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR

---
**Related PRs — config-CRC CCITT standardization (finding MJ-7):**
- OpenDisplay/py-opendisplay#117 — Python client `calculate_config_crc` → CCITT
- OpenDisplay/Firmware#83 — Arduino toolbox-outer validation → CCITT (advisory)
- OpenDisplay/opendisplay.org#27 — website `parseConfigBytes` read-back (zero length bytes)

Already canonical (no change): toolbox writer, nRF firmware, Silabs firmware. `opendisplay-js` (TS) intentionally not updated (abandoned).