### PR TITLE
Fix several independent minor website bugs

### DIFF
--- a/httpdocs/firmware/toolbox/index.html
+++ b/httpdocs/firmware/toolbox/index.html
@@ -30,7 +30,7 @@
       // Only use polyfill on Android with WebUSB support
       if (isAndroid && navigator.usb) {
         try {
-          const { serial } = await import('/js/serial.js');
+          const { serial } = await import('/js/web-serial-polyfill.js');
           
           // Try to replace navigator.serial - on Android it might exist but not work
           try {
@@ -430,6 +430,14 @@
 <script src="/js/ble-common.js"></script>
 <script>
 let bleLib = null;
+// Live resolve/reject for the current connectToBleDevice() attempt. The persistent
+// OpenDisplayBLE callbacks are created once but must settle whichever promise is active,
+// so they read these instead of capturing the first attempt's resolve/reject.
+let bleConnectResolve = null;
+let bleConnectReject = null;
+// Single nRF Web Tools instance, reused across board changes so its click listener
+// is never stacked (NrfWebTools.init() calls addEventListener, which onclick=null can't remove).
+let nrfInstaller = null;
 
 function isToolboxBleOnlyMode() {
   return window.OpenDisplayBrowser
@@ -970,7 +978,7 @@ function updateTotalBytesDisplay() {
   bytesView.parentNode.insertBefore(counter, bytesView);
 }
 function hexPad(n, len=2){return n.toString(16).toUpperCase().padStart(len,'0');}
-function numToBytesLE(num, size){ const out=[]; for(let i=0;i<size;i++){ out.push(num & 0xFF); num = num >> 8; } return out; }
+function numToBytesLE(num, size){ const out=[]; num=Math.floor(num); for(let i=0;i<size;i++){ out.push(num & 0xFF); num = Math.floor(num / 256); } return out; }
 function numToBytesBE(num, size){ const out=[]; for(let i=size-1;i>=0;i--){ out.push((num >> (i*8)) & 0xFF); } return out; }
 function parseSizeToken(sizeTok){ 
   if(!sizeTok) return null; 
@@ -2130,6 +2138,9 @@ function connectToBleDevice(useCachedDevice = false) {
       reject(new Error('Device filter needed'));
       return;
     }
+    // Point the persistent callbacks at this attempt's promise.
+    bleConnectResolve = resolve;
+    bleConnectReject = reject;
     if (!bleLib) {
       bleLib = new OpenDisplayBLE({
         deviceNamePrefix: namePrefix,
@@ -2139,7 +2150,7 @@ function connectToBleDevice(useCachedDevice = false) {
           addLog('BLE connection established', 'success');
           document.getElementById("connectbutton").innerHTML = 'Disconnect';
           await ensureAuthenticatedOnConnect();
-          resolve();
+          if (bleConnectResolve) bleConnectResolve();
         },
         onDisconnect: () => {
           addLog('Device disconnected.');
@@ -2150,7 +2161,7 @@ function connectToBleDevice(useCachedDevice = false) {
           addLog(`Error: ${error.name} - ${error.message}`, 'error');
           setStatus(`Error: ${error.message}`);
           document.getElementById("connectbutton").innerHTML = 'Connect';
-          reject(error);
+          if (bleConnectReject) bleConnectReject(error);
         },
         onNotification: handleNotification,
         onLog: (message, type) => {
@@ -2514,10 +2525,14 @@ function handleDriverBoardChange() {
       installNrfBtn.style.display = 'block';
       // Initialize nRF Web Tools
       if (typeof NrfWebTools !== 'undefined') {
-        // Remove any existing onclick to avoid duplicates
-        installNrfBtn.onclick = null;
-        // Create new instance - firmware path is relative to toolbox page
-        const nrfInstaller = new NrfWebTools(installNrfBtn, 'firmware/NRF52840.zip');
+        // Create once and reuse. NrfWebTools.init() attaches a click listener via
+        // addEventListener; constructing a new instance per board change would stack
+        // listeners (one click -> N installs), and installNrfBtn.onclick=null can't
+        // remove an addEventListener handler.
+        if (!nrfInstaller) {
+          // firmware path is relative to toolbox page
+          nrfInstaller = new NrfWebTools(installNrfBtn, 'firmware/NRF52840.zip');
+        }
       } else {
         installNrfBtn.onclick = () => {
           alert('nRF Web Tools library not loaded. Please refresh the page.');

--- a/httpdocs/firmware/toolbox/js/serial.js
+++ b/httpdocs/firmware/toolbox/js/serial.js
@@ -434,7 +434,7 @@ export class SerialPort {
             'index': this.controlInterface_.interfaceNumber,
         }, buffer);
         if (result.status != 'ok') {
-            throw new DOMException('NetworkError', 'Failed to set line coding.');
+            throw new DOMException('Failed to set line coding.', 'NetworkError');
         }
     }
 }

--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -3433,7 +3433,7 @@ class OpenDisplayBLE {
       const GRAY4_LUT = [3, 1, 2, 0];
       const GRAY4_LUT_V2 = [3, 2, 1, 0];
       const panelId = panelIcType != null ? Number(panelIcType) : NaN;
-      const grayLut = (panelId === 0x16 || panelId === 0x28 || panelId === 22 || panelId === 40)
+      const grayLut = (panelId === 0x28 || panelId === 40 || panelId === 0x48 || panelId === 72)
         ? GRAY4_LUT_V2
         : GRAY4_LUT;
       const bytesPerRow = Math.ceil(imageWidth / 8);

--- a/httpdocs/js/opendisplay-msd.js
+++ b/httpdocs/js/opendisplay-msd.js
@@ -116,7 +116,10 @@
         const sensorType = data[1] | (data[2] << 8);
         if (sensorType === SENSOR_TYPE_SHT40 && out.sht40StartByte === null) {
           let start = data[5];
-          if (start === 0xff || start === undefined) start = 7;
+          // Firmware treats a start byte of 0 (and 0xff) as "unset -> default 7"
+          // (see sensor_sht40.cpp sht40_msd_start); mirror that so 0 doesn't get
+          // decoded as a literal offset yielding a bogus -40 C reading.
+          if (start === 0 || start === 0xff || start === undefined) start = 7;
           start = start & 0xff;
           // SHT40 reads 3 bytes (start..start+2) from the 11-byte dynamic region,
           // so start must be <= 8. Validate symmetrically with BQ27220's idx <= 10

--- a/httpdocs/js/web-serial-polyfill.js
+++ b/httpdocs/js/web-serial-polyfill.js
@@ -434,7 +434,7 @@ export class SerialPort {
             'index': this.controlInterface_.interfaceNumber,
         }, buffer);
         if (result.status != 'ok') {
-            throw new DOMException('NetworkError', 'Failed to set line coding.');
+            throw new DOMException('Failed to set line coding.', 'NetworkError');
         }
     }
 }


### PR DESCRIPTION
Batch of independent, surgical fixes for minor website/toolbox bugs. Each is self-contained and avoids the direct-write/connection-state and config-CRC areas covered by other in-flight PRs.

### Fixes & verification

- [x] **Toolbox serial polyfill import 404** — `firmware/toolbox/index.html` imported `/js/serial.js`, which doesn't exist. Pointed it at `/js/web-serial-polyfill.js` (the existing file at `httpdocs/js/`, byte-identical to the toolbox's `js/serial.js`, exporting `serial`). Verified both candidate files `export const serial`.

- [x] **"Configure over Bluetooth" retry hang** — the `OpenDisplayBLE` instance + `onConnect`/`onError` are created once and captured the *first* attempt's `resolve`/`reject`; a second attempt's promise never settled. Now the callbacks settle live `bleConnectResolve`/`bleConnectReject` vars that are re-pointed at each attempt's promise. Reasoned through: retries now resolve/reject the current promise.

- [x] **Stacked `NrfWebTools` instances** — `installNrfBtn.onclick = null` can't remove the `addEventListener('click', …)` handler set in `NrfWebTools.init()`, and a new instance was built per board change, so toggling boards stacked handlers (one click → N installs). Now a single instance is created once and reused.

- [x] **4-gray v2 LUT applied to wrong panels** — `ble-common.js` used the v2 LUT for `{0x16, 0x28}`; ground truth (matches Python `display_palettes.py`) is v2 for `{0x28, 0x48}` only. Corrected the panel set. Node assertion confirms `0x28`/`0x48` → v2, `0x16` → v1.

- [x] **SHT40 advertisement start-byte 0** — JS treated a start byte of `0` as a literal offset (decoding a bogus −40 °C reading); firmware (`sensor_sht40.cpp` `sht40_msd_start`) treats `0` (and `0xff`) as "unset → default 7". JS now mirrors that. Node assertion confirms `0`/`0xff` → `7`, `5` → `5`.

- [x] **DOMException args swapped** — the serial polyfill threw `new DOMException('NetworkError', 'Failed to set line coding.')` with message/name reversed, so `err.name === 'NetworkError'` never matched. Swapped to `(message, name)` in both byte-identical copies (`js/web-serial-polyfill.js` and `firmware/toolbox/js/serial.js`); `diff` confirms the two files remain identical. Node assertion confirms `err.name === 'NetworkError'`.

- [x] **`configured_at` uint48 via 32-bit shifts** — `numToBytesLE` used `num = num >> 8`, a 32-bit signed op that overflows once a Unix-seconds timestamp exceeds 2^31 (year 2038). Switched to `Math.floor(num / 256)`. Node assertion confirms a year-2039 timestamp round-trips (old impl produced sign-extended `…,255,255`); small values byte-for-byte match the old output.

### Testing
`node --check` passes on all four edited JS files. Pure-logic fixes (4-gray LUT, SHT40 default, DOMException swap, uint48) covered by Node assertions (all pass). HTML/DOM fixes (serial import, BLE retry, NrfWebTools) reasoned through against the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR