### PR TITLE
Row-pad mono/2bpp/4bpp single-plane BLE image encodings

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -3396,9 +3396,14 @@ class OpenDisplayBLE {
             nibblePosition = 1;
           }
         }
-      }
-      if (nibblePosition === 0) {
-        byteData.push(currentByte);
+        // Row-pad to a byte boundary: flush the pending high nibble so each row
+        // starts a new byte. Matches encode_4bpp's per-row padding on the Python
+        // sender and the row-padded firmware. For even widths this is a no-op.
+        if (nibblePosition === 0) {
+          byteData.push(currentByte);
+          currentByte = 0;
+          nibblePosition = 1;
+        }
       }
     } else if (colorScheme === 6) {
       // 16 gray (4bpp): same nibble order as 6-color — even x = high nibble, odd x = low; 0=black .. 15=white (Seeed TFT_GRAY_*).
@@ -3422,9 +3427,14 @@ class OpenDisplayBLE {
             nibblePosition = 1;
           }
         }
-      }
-      if (nibblePosition === 0) {
-        byteData.push(currentByte);
+        // Row-pad to a byte boundary: flush the pending high nibble so each row
+        // starts a new byte. Matches encode_4bpp's per-row padding on the Python
+        // sender and the row-padded firmware. For even widths this is a no-op.
+        if (nibblePosition === 0) {
+          byteData.push(currentByte);
+          currentByte = 0;
+          nibblePosition = 1;
+        }
       }
     } else if (colorScheme === 5) {
       // bb_epaper 4-gray: two concatenated 1bpp controller planes (plane0 then plane1).
@@ -3523,9 +3533,14 @@ class OpenDisplayBLE {
             pixelInByte = 0;
           }
         }
-      }
-      if (pixelInByte > 0) {
-        byteData.push(currentByte);
+        // Row-pad to a byte boundary: flush the partially filled byte so each row
+        // starts a new byte (ceil(w/4) bytes/row). Matches encode_2bpp's per-row
+        // padding on the Python sender and the row-padded firmware. No-op for w%4==0.
+        if (pixelInByte > 0) {
+          byteData.push(currentByte);
+          currentByte = 0;
+          pixelInByte = 0;
+        }
       }
     } else {
       // Monochrome: 1 bit per pixel
@@ -3549,12 +3564,17 @@ class OpenDisplayBLE {
             bitPosition = 7;
           }
         }
-      }
-      if (bitPosition !== 7) {
-        byteData.push(currentByte);
+        // Row-pad to a byte boundary: flush the partially filled byte so each row
+        // starts a new byte (ceil(w/8) bytes/row). Matches np.packbits(axis=1) on
+        // the Python sender and the row-padded firmware. No-op for w%8==0.
+        if (bitPosition !== 7) {
+          byteData.push(currentByte);
+          currentByte = 0;
+          bitPosition = 7;
+        }
       }
     }
-    
+
     return byteData;
   }
 


### PR DESCRIPTION
## Summary

The Web Bluetooth encoder in `httpdocs/js/ble-common.js` **flat-packed** the single-plane image formats across row boundaries: the byte/nibble accumulator only flushed on a full byte, never at end of row. On panels whose width isn't a multiple of 8 (e.g. the 122-wide EP213) this carried pixels of the next row into a shared byte, misaligning the rendered image.

This is the **web counterpart** to the firmware row-padding change; the Python sender (`py-opendisplay`) already row-pads (`np.packbits(axis=1)` for 1bpp/bitplanes, per-row reshape padding for 2bpp/4bpp). Team decision: standardize on **row-padded everywhere**.

## What changed

Added a per-row flush to the four flat-packing single-plane branches so each row starts on a byte boundary:

- `colorScheme 0` — 1bpp mono → `ceil(w/8)` bytes/row
- `colorScheme 3` — 2bpp (B/W+Red+Yellow) → `ceil(w/4)` bytes/row
- `colorScheme 4` — 4bpp 6-color → `ceil(w/2)` bytes/row
- `colorScheme 6` — 4bpp 16-gray → `ceil(w/2)` bytes/row

For widths that are already a multiple of the packing factor the output is **byte-identical**. `uncompressedSize` is derived from `byteData.length`, so it grows correctly with the padding — no separate flat `w*h/8` computation to fix.

Not touched: the BWR/BWY two-plane path (color schemes 1/2, handled in a separate PR) and GRAY4 (scheme 5, already row-padded).

## Verification

`node --check` passes. A Node harness confirms per-format output on an all-set image:

| scheme | w=13 (odd) bytes/row | expected `ceil(w/ppb)` | w=16 (÷8) byte-identical to before |
|---|---|---|---|
| 1bpp mono | 2 | 2 | yes |
| 2bpp | 4 | 4 | yes |
| 4bpp 6-color | 7 | 7 | yes |
| 4bpp 16-gray | 7 | 7 | yes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR

---
**Companion PR:** OpenDisplay/Firmware#87 (firmware row-padded 1/2/4bpp sizing). Python already row-pads. All three senders + firmware now agree.