### PR TITLE
Fix protocol spec/doc inaccuracies

### DIFF
--- a/httpdocs/protocol/ble-flow.html
+++ b/httpdocs/protocol/ble-flow.html
@@ -840,7 +840,7 @@ payload is exactly the same blob as a single BLE <em>write</em> to the OpenDispl
     <div class="flow-step">
       <h4>Commands <code>0x0064</code> / <code>0x0065</code></h4>
       <p>
-        Defined for implementations that buffer the full image before refresh. Reference firmware returns an error if sent.
+        Defined for implementations that buffer the full image before refresh. Reference firmware does not implement these opcodes: they fall through to the unknown-command path, which sends <strong>no response</strong>. A client must not wait for a reply — these are silently ignored.
       </p>
     </div>
   </div>
@@ -862,6 +862,7 @@ payload is exactly the same blob as a single BLE <em>write</em> to the OpenDispl
       <li><code>0x0040</code> — Read configuration</li>
       <li><code>0x0041</code> — Write configuration (first chunk or small config)</li>
       <li><code>0x0042</code> — Write configuration (subsequent chunks)</li>
+      <li><code>0x0045</code> — Clear stored configuration (erases the saved config blob; replies <code>0x00 0x45</code> on success, <code>0xFF 0x45</code> on failure)</li>
       <li><code>0x0043</code> — Read firmware version (plaintext; allowed without encryption session)</li>
       <li><code>0x0044</code> — Read 16-byte manufacturer specific data (MSD)</li>
       <li><code>0x0050</code> — Authenticate / encryption handshake (see <a href="#encryption-authentication" style="color: var(--accent);">Encryption</a>)</li>

--- a/httpdocs/protocol/display-data-format.html
+++ b/httpdocs/protocol/display-data-format.html
@@ -246,8 +246,8 @@
         <div class="bit set">1</div>
         <div class="bit">0</div>
       </div>
-      <div class="byte-box">0xB6</div>
-      <span style="color: var(--muted-foreground);">(10110110 binary = 182 decimal = 0xB6 hex)</span>
+      <div class="byte-box">0xB2</div>
+      <span style="color: var(--muted-foreground);">(10110010 binary = 178 decimal = 0xB2 hex)</span>
     </div>
   </div>
 
@@ -294,10 +294,10 @@
           <div class="bit set">1</div>
           <div class="bit">0</div>
         </div>
-        <div class="byte-box">0xB6</div>
+        <div class="byte-box">0xBA</div>
       </div>
     </div>
-    
+
     <div class="plane-visual">
       <div class="plane-label">Plane 2 (Red):</div>
       <div class="byte-visual">
@@ -311,11 +311,11 @@
           <div class="bit">0</div>
           <div class="bit">0</div>
         </div>
-        <div class="byte-box">0x24</div>
+        <div class="byte-box">0x28</div>
       </div>
     </div>
-    
-    <p><strong>Final Data:</strong> <code>0xB6, 0x24</code> (Plane 1 first, then Plane 2)</p>
+
+    <p><strong>Final Data:</strong> <code>0xBA, 0x28</code> (Plane 1 first, then Plane 2)</p>
   </div>
 
   <div class="col panel">
@@ -359,20 +359,20 @@
     <div class="byte-visual">
       <span>Byte:</span>
       <div class="bit-visual">
+        <div class="bit">0</div>
         <div class="bit set">1</div>
-        <div class="bit">0</div>
         <span style="margin: 0 4px;">|</span>
         <div class="bit">0</div>
         <div class="bit">0</div>
         <span style="margin: 0 4px;">|</span>
-        <div class="bit">1</div>
+        <div class="bit set">1</div>
         <div class="bit">0</div>
         <span style="margin: 0 4px;">|</span>
         <div class="bit set">1</div>
         <div class="bit set">1</div>
       </div>
-      <div class="byte-box">0x93</div>
-      <span style="color: var(--muted-foreground);">(W=01, B=00, Y=10, R=11 = 10010011 = 0x93)</span>
+      <div class="byte-box">0x4B</div>
+      <span style="color: var(--muted-foreground);">(W=01, B=00, Y=10, R=11 = 01001011 = 0x4B)</span>
     </div>
     <p><strong>Bit pairs (left to right):</strong> 01 (White), 00 (Black), 10 (Yellow), 11 (Red)</p>
   </div>
@@ -584,8 +584,8 @@
         <div class="bit">0</div>
         <div class="bit set">1</div>
       </div>
-      <div class="byte-box">0xE5</div>
-      <span style="color: var(--muted-foreground);">(W=11, B=00, LG=10, DG=01 = 11100101 = 0xE5)</span>
+      <div class="byte-box">0xC9</div>
+      <span style="color: var(--muted-foreground);">(W=11, B=00, LG=10, DG=01 = 11001001 = 0xC9)</span>
     </div>
     <p><strong>Bit pairs (left to right):</strong> 11 (White), 00 (Black), 10 (Light Gray), 01 (Dark Gray)</p>
   </div>
@@ -673,8 +673,9 @@ Byte 1: Pixels 8-15 (Row 2: 8-11, Row 3: 12-15)</code>
 <code>Packet Type: 0x82
 Offset 0: packet_type (1 byte) = 0x82
 Offset 1-2: image_length (2 bytes, uint16, little-endian)
-Offset 3 to (3+image_length-1): image_data (variable)
-Offset (3+image_length) to (6+image_length): poll_interval (4 bytes, uint32, little-endian)</code>
+Offset 3-6: poll_interval (4 bytes, uint32, little-endian)
+Offset 7: refresh_type (1 byte) = 0 (normal) or 1 (fast)
+Offset 8 to (8+image_length-1): image_data (variable)</code>
     </div>
     <ul style="margin: 12px 0; padding-left: 20px; color: var(--muted-foreground); line-height: 1.8;">
       <li><strong>Image Data:</strong> Raw encoded pixel data (or compressed using zlib)</li>


### PR DESCRIPTION
Fixes several inaccuracies in the published protocol docs that would mislead third-party implementers. HTML/text-only edits to `httpdocs/protocol/` — no JS touched.

## 1. Wrong worked-example hex bytes (`display-data-format.html`)
Recomputed each worked example from the page's own documented packing rules so byte-boxes, captions, and bit visuals agree:

- **Scheme 0 (mono, W=1/B=0):** pixels `W B W W B B W B` → `10110010` = **0xB2** (was 0xB6/`10110110`).
- **Scheme 1 (B/W+Red):** pixels `W B R W R B W B`. Plane 1 (white or red = 1) → `10111010` = **0xBA** (was 0xB6). Plane 2 (red = 1) → `00101000` = **0x28** (was 0x24). Final data → `0xBA, 0x28`.
- **Scheme 3 (2bpp, W=01 B=00 Y=10 R=11):** pixels `W B Y R` → `01 00 10 11` = **0x4B** (was 0x93 with a mismatched bit visual and caption `10010011`). Corrected the leading bit cell so the visual reads 0x4B.
- **Scheme 5 (4 grayscale, W=11 B=00 LG=10 DG=01):** pixels `W B LG DG` → `11001001` = **0xC9** (was 0xE5/`11100101`; the bit visual already read 0xC9).

Schemes 2 and 4 examples were already correct and were left unchanged.

Source verified: the packing rules documented on the same page (bits-per-pixel, color codes, MSB-first packing).

## 2. `0x82` packet layout contradiction
`display-data-format.html` described `image_data` at offset 3 with `poll_interval` trailing and no refresh byte, contradicting `basic-standard.html`. Made `display-data-format.html` match the authoritative layout: `poll_interval` @ offset 3–6, `refresh_type` @ offset 7, `image_data` @ offset 8.

Source verified: `basic-standard.html` is internally self-consistent (byte table + worked example `0x82 0x88 0x13 0x2C 0x01 0x00 0x00 0x00 …`, total = 8 + image_length). No in-tree firmware implements the Basic `0x82` "New Image" image packet (the Silabs `0x0082` handler is the unrelated NFC endpoint, `CMD_NFC_ENDPOINT`), so `basic-standard.html` was taken as authoritative.

## 3. Missing command `0x0045` (Clear Config)
Added `0x0045` — Clear stored configuration — to the command reference in `ble-flow.html`. Erases the saved config blob; replies `0x00 0x45` on success, `0xFF 0x45` on failure.

Source verified: `OpenDisplay-Firmware/src/communication.cpp:407-419` (`handleClearConfig`) and dispatch `case 0x0045:` at line 561.

## 4. False error-response claim for `0x0064` / `0x0065`
The spec claimed reference firmware "returns an error if sent." It does not: these opcodes have no `case` in the command switch and fall through to `default`, which only logs and sends **no response**. Corrected the text so clients don't wait for a reply that never arrives.

Source verified: `OpenDisplay-Firmware/src/communication.cpp:546-615` — no case for `0x0064`/`0x0065`; the `default` branch (611-614) calls `writeSerial` only, never `sendResponse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR
