### PR TITLE
Fix BLE connection-robustness: abort in-flight state machines and dedupe notification listener

### DIFF
--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -64,6 +64,11 @@ class OpenDisplayBLE {
     this.autoReconnectEnabled = true; // disabled by explicit user disconnect
     // Bound once so add/removeEventListener share the same reference.
     this._onDisconnect = () => this.handleDisconnect();
+    // Bound once as well: connectToGATT() re-runs on auto-reconnect against
+    // Chrome's cached characteristic object, so a fresh anonymous listener each
+    // time would stack and process every notification twice. Removing this exact
+    // reference before adding it keeps the count at one per characteristic.
+    this._onNotification = (event) => this.handleNotification(event);
     this.configYAML = null;
     this.packetSchema = null;  // Parsed packet schema from YAML
     this.packetSizes = {};     // Cached packet sizes
@@ -744,7 +749,11 @@ class OpenDisplayBLE {
       // Try to enable notifications with retries
       try {
         await this.enableNotificationsWithRetry(5, 200);
-        this.characteristic.addEventListener('characteristicvaluechanged', (event) => this.handleNotification(event));
+        // Remove first so a reconnect against Chrome's cached characteristic
+        // object doesn't stack a second listener (which would process every
+        // notification twice). No-op the first time / on a fresh characteristic.
+        this.characteristic.removeEventListener('characteristicvaluechanged', this._onNotification);
+        this.characteristic.addEventListener('characteristicvaluechanged', this._onNotification);
         this.log('Notifications started', 'success');
       } catch (notifyError) {
         this.log(`Failed to start notifications: ${notifyError.name} - ${notifyError.message}`, 'error');
@@ -857,10 +866,61 @@ class OpenDisplayBLE {
     this.service = null;
     this.characteristic = null;
     this.isConnected = false;
+    // Abort any in-flight built-in operation (must run before we clear the
+    // configReadState fields below, since it inspects .active to settle callbacks).
+    this.abortInFlightOperations(new Error('Disconnected'));
     this.configReadState.active = false;
     this.configReadState.chunks = {};
     this.configReadState.receivedLength = 0;
     this.configReadState.totalLength = 0;
+  }
+
+  /**
+   * Abort every in-flight built-in operation, settling its pending callback with
+   * `err` and clearing state so a disconnect mid-transfer surfaces an error
+   * instead of hanging silently, and so a later operation starts fresh. Only the
+   * config-read state's callback was previously handled here; directWrite/dfu/
+   * firmwareVersion were left active with their callbacks never invoked (and a
+   * lingering directWriteState.active blocked the next sendCanvasToDisplay).
+   */
+  abortInFlightOperations(err) {
+    // Config read ("Read Toolbox").
+    if (this.configReadState.active) {
+      const onComplete = this.configReadState.onComplete;
+      this.configReadState.active = false;
+      this.configReadState.onComplete = null;
+      this.configReadState.onProgress = null;
+      if (onComplete) onComplete(null, err);
+    }
+
+    // Direct write (canvas/image upload). _abortDirectWrite settles
+    // onComplete(false, err) and drops directWriteState so the next
+    // sendCanvasToDisplay starts fresh instead of throwing 'already in progress'.
+    if (this.directWriteState && this.directWriteState.active) {
+      this._abortDirectWrite(err);
+    } else {
+      this.directWriteState = null;
+    }
+
+    // DFU firmware upload.
+    if (this.dfuState.active) {
+      const onError = this.dfuState.onError;
+      const onComplete = this.dfuState.onComplete;
+      this.resetDFUState();
+      this.dfuState.onProgress = null;
+      this.dfuState.onComplete = null;
+      this.dfuState.onError = null;
+      if (onError) onError(err);
+      else if (onComplete) onComplete(false, err);
+    }
+
+    // Firmware version read.
+    if (this.firmwareVersionState.active) {
+      const onComplete = this.firmwareVersionState.onComplete;
+      this.firmwareVersionState.active = false;
+      this.firmwareVersionState.onComplete = null;
+      if (onComplete) onComplete(null, err);
+    }
   }
   
   /**


### PR DESCRIPTION
Two connection-robustness fixes in `httpdocs/js/ble-common.js`.

### 1. State machines don't abort on disconnect
`resetState()` (called on both user disconnect and GATT `gattserverdisconnected`) cleared only `configReadState`. `directWriteState`, `dfuState`, and `firmwareVersionState` were left `active` with their pending callbacks never invoked and no timeout. Consequences:
- A disconnect mid-transfer left "Read Toolbox" / firmware-version read / DFU upload hung silently — the caller's `onComplete`/`onError` never fired.
- `directWriteState.active` staying `true` made the next `sendCanvasToDisplay` throw `'Direct write already in progress'` until a page reload.

Fix: a new `abortInFlightOperations(err)` helper, invoked from `resetState()`, settles each pending callback with a clear "Disconnected" error and clears `configReadState`/`directWriteState`/`dfuState`/`firmwareVersionState` so a later operation starts fresh. The direct-write path reuses the existing `_abortDirectWrite(err)` so cleanup stays consistent with that state machine.

### 2. Duplicate notification listeners on auto-reconnect
`connectToGATT()` added a fresh anonymous `characteristicvaluechanged` listener on every call. Auto-reconnect re-runs `connectToGATT()` against Chrome's cached characteristic object, so after one reconnect every notification was processed twice — double-counting the config-read length (→ truncated config) and double-driving the direct-write chunk pump.

Fix: the handler is now a single bound reference (`this._onNotification`, created once in the constructor) that is `removeEventListener`'d before being re-added, mirroring the existing `this._onDisconnect` pattern already in the file. Exactly one listener per characteristic, so notifications are processed once after a reconnect.

### Verification
- `node --check httpdocs/js/ble-common.js` passes.
- A Node `vm` harness (14 assertions, all passing):
  - Simulated disconnect asserts pending `configRead`/`directWrite`/`dfu`/`firmwareVersion` callbacks are each settled with the error and their state cleared (`directWriteState === null`); `resetState()` with nothing in flight is a safe no-op.
  - Simulated connect → reconnect against a shared (Chrome-cached) characteristic object asserts exactly one listener is attached and each notification fires the handler once, not twice.

### Overlap with #28 (`fix/direct-write-ack-timeout`)
This branches off `main` and touches the same direct-write / `resetState` area as #28. Per the team this textual overlap is expected and accepted ("fix later") — #28 adds a direct-write ack timer and expands `_abortDirectWrite` (clearing that timer); this PR calls `_abortDirectWrite` from the disconnect path. The two are semantically compatible (if #28's ack-timer field exists, its `_abortDirectWrite` already clears it), and any textual conflict at merge time will be reconciled then. This PR deliberately does not touch the CRC (#27) or encoding (#26/#30) areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR