### PR TITLE
docs: correct screen_timeout_seconds semantics (30 s clamp, AXP2101 forced-0)

### DIFF
--- a/httpdocs/firmware/toolbox/config.yaml
+++ b/httpdocs/firmware/toolbox/config.yaml
@@ -396,7 +396,7 @@ ble_proto:
         description: Min awake window after first boot or button wake; 0 = default 120 s
       - name: screen_timeout_seconds
         size: 1
-        description: debounce timer for display power for rapid update cycles (0-255 s; 0 = disabled, power down immediately)
+        description: EPD keep-alive; seconds the panel stays powered after a refresh before shutdown (0-30, values above 30 clamped; 0 = power off immediately; forced 0 when an AXP2101 PMIC is present)
       - name: reserved
         size: 4
         description: Reserved bytes for future use


### PR DESCRIPTION
The toolbox `config.yaml` description for `screen_timeout_seconds` was stale. It read "debounce timer for display power for rapid update cycles (0-255 s; 0 = disabled, power down immediately)", implying a full 0-255 second range.

The firmware (bcee206 / #100) now:
- Treats this as an EPD keep-alive: seconds the panel stays powered after a refresh before shutdown.
- Clamps the value to `EPD_KEEPALIVE_MAX_S` (30 s); anything above 30 is reduced to 30.
- Forces the value to 0 (power off immediately) on boards with an AXP2101 PMIC.

This one-line change updates the description to match the real firmware behavior. No structural/YAML changes — `python3 -c "import yaml; yaml.safe_load(...)"` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)