### PR TITLE
Fix reTerminal E1003 preset missing battery-sense config

### DIFF
--- a/httpdocs/firmware/toolbox/simple-config-presets.json
+++ b/httpdocs/firmware/toolbox/simple-config-presets.json
@@ -667,9 +667,9 @@
             "clk": "7"
          },
          "powerDefaults": {
-            "battery_sense_pin": "0xFF",
-            "battery_sense_enable_pin": "0xFF",
-            "voltage_scaling_factor": "0x0"
+            "battery_sense_pin": "1",
+            "battery_sense_enable_pin": "40",
+            "voltage_scaling_factor": "0xa1"
          },
          "led": {
             "instance_number": "0x0",


### PR DESCRIPTION
battery_sense_pin/enable_pin were 0xFF (disabled) and voltage_scaling_factor was 0, so every E1003 provisioned via the toolbox got no battery reading. Set to the values confirmed on hardware: GPIO1 ADC input, GPIO40 (VBAT_EN) divider enable, and a 161 (0xa1) scaling factor for the 2:1 divider.

```
python3 device_cli.py read-msd --addr 44:1B:F6:C0:08:F5 --key XXXXXX
Connecting to 44:1B:F6:C0:08:F5...
Connected.
Authenticating...
Authenticated (encrypted session established).
Reading MSD data...
Battery voltage: 3.99 V
Chip temperature: 29.0 C
Reboot flag: False
Connection requested: False
Loop counter: 2
Dynamic data (bytes 2-12): 0000000000000000000000
```

Found the right GPIO at: https://github.com/ar0v3r/reTerminal-E1003-ESPHome
Battery voltage calibration curves are at: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/