### PR TITLE
Add SEEED_LI_ION capacity estimator for reTerminal E1001-E1003

### DIFF
--- a/httpdocs/firmware/toolbox/config.yaml
+++ b/httpdocs/firmware/toolbox/config.yaml
@@ -356,6 +356,9 @@ ble_proto:
           4:
             name: lithium_primary
             description: Lithium primary battery
+          5:
+            name: seeed_li_ion
+            description: 1s li-ion, Seeed reTerminal E-series (E1001-E1003) discharge curve
       - name: voltage_scaling_factor
         size: 2
         description: Voltage scaling / divider factor (implementation-specific)

--- a/httpdocs/firmware/toolbox/index.html
+++ b/httpdocs/firmware/toolbox/index.html
@@ -3392,6 +3392,9 @@ function mergeSimpleConfigToFull() {
       if (simpleConfigSelections.driverBoard.powerDefaults.battery_sense_flags !== undefined) {
         powerOptionFields.battery_sense_flags = simpleConfigSelections.driverBoard.powerDefaults.battery_sense_flags;
       }
+      if (simpleConfigSelections.driverBoard.powerDefaults.capacity_estimator !== undefined) {
+        powerOptionFields.capacity_estimator = simpleConfigSelections.driverBoard.powerDefaults.capacity_estimator;
+      }
       if (simpleConfigSelections.driverBoard.powerDefaults.deep_sleep_current_ua !== undefined) {
         powerOptionFields.deep_sleep_current_ua = simpleConfigSelections.driverBoard.powerDefaults.deep_sleep_current_ua;
       }

--- a/httpdocs/firmware/toolbox/simple-config-presets.json
+++ b/httpdocs/firmware/toolbox/simple-config-presets.json
@@ -513,7 +513,8 @@
             "battery_sense_pin": "1",
             "battery_sense_enable_pin": "21",
             "voltage_scaling_factor": "0xb1",
-            "deep_sleep_current_ua": "0"
+            "deep_sleep_current_ua": "0",
+            "capacity_estimator": "5"
          },
          "buttons": {
             "instance_number": "0x0",
@@ -605,7 +606,8 @@
             "battery_sense_pin": "1",
             "battery_sense_enable_pin": "21",
             "voltage_scaling_factor": "0xb1",
-            "deep_sleep_current_ua": "0"
+            "deep_sleep_current_ua": "0",
+            "capacity_estimator": "5"
          },
          "buttons": {
             "instance_number": "0x0",
@@ -669,7 +671,8 @@
          "powerDefaults": {
             "battery_sense_pin": "1",
             "battery_sense_enable_pin": "40",
-            "voltage_scaling_factor": "0xa1"
+            "voltage_scaling_factor": "0xa1",
+            "capacity_estimator": "5"
          },
          "led": {
             "instance_number": "0x0",

--- a/httpdocs/js/opendisplay-battery.js
+++ b/httpdocs/js/opendisplay-battery.js
@@ -9,7 +9,8 @@
     LI_ION: 1,
     LIFEPO4: 2,
     SUPERCAP: 3,
-    LITHIUM_PRIMARY: 4
+    LITHIUM_PRIMARY: 4,
+    SEEED_LI_ION: 5
   };
 
   var SOC_LI_ION = [
@@ -32,11 +33,21 @@
     [4500, 100], [3000, 0]
   ];
 
+  // Seeed reTerminal E-series (E1001/E1002/E1003) single-cell LiPo, Seeed's own
+  // ESPHome reference discharge curve.
+  var SOC_SEEED_LI_ION = [
+    [4150, 100], [4055, 95], [3960, 90], [3935, 85], [3910, 80], [3880, 75],
+    [3850, 70], [3825, 65], [3800, 60], [3775, 55], [3750, 50], [3715, 45],
+    [3680, 40], [3630, 35], [3580, 30], [3535, 25], [3490, 20], [3450, 15],
+    [3410, 10], [3300, 5], [3270, 0]
+  ];
+
   var CHEMISTRY_LABELS = {
     1: 'Li-Ion',
     2: 'LiFePO4',
     3: 'Supercap',
-    4: 'Lithium primary'
+    4: 'Lithium primary',
+    5: 'Seeed Li-Ion'
   };
 
   function interpolate(table, voltageMv) {
@@ -66,6 +77,8 @@
         return interpolate(SOC_LITHIUM_PRIMARY, voltageMv);
       case CapacityEstimator.SUPERCAP:
         return interpolate(SOC_SUPERCAP, voltageMv);
+      case CapacityEstimator.SEEED_LI_ION:
+        return interpolate(SOC_SEEED_LI_ION, voltageMv);
       default:
         return null;
     }


### PR DESCRIPTION
py-opendisplay gained a dedicated SEEED_LI_ION chemistry (value 5) with Seeed's own discharge curve, since the generic LI_ION curve diverges significantly for the reTerminal E-series. Mirror it into the toolbox's protocol schema and JS battery decoder, and default the E1001/E1002/E1003 presets to it (reterminal-sticky stays on LI_ION since it has no ADC voltage-divider sensing).


See also https://github.com/OpenDisplay/py-opendisplay/pull/133