### PR TITLE
fix(toolbox): honour preset rotation, default PhotoPainter to 180°

### DIFF
--- a/httpdocs/firmware/toolbox/index.html
+++ b/httpdocs/firmware/toolbox/index.html
@@ -3654,7 +3654,14 @@ function createDisplayConfig(display, driverBoardId) {
     : ((config.transmission_modes != null && `${config.transmission_modes}` !== '')
       ? `${config.transmission_modes}`
       : '10');
-  
+  // The enclosure decides the viewing orientation, so a driver board's
+  // defaultRotation wins over a panel preset's own rotation quirk.
+  const rotation = (driverBoard && driverBoard.defaultRotation != null && `${driverBoard.defaultRotation}` !== '')
+    ? `${driverBoard.defaultRotation}`
+    : ((config.rotation != null && `${config.rotation}` !== '')
+      ? `${config.rotation}`
+      : '0');
+
   return {
     instance_number: '0x0',
     display_technology: '1',
@@ -3664,7 +3671,7 @@ function createDisplayConfig(display, driverBoardId) {
     active_width_mm: config.active_width_mm,
     active_height_mm: config.active_height_mm,
     legacy_tagtype: '0x0',
-    rotation: '0',
+    rotation: rotation,
     reset_pin: pins.reset,
     busy_pin: pins.busy,
     dc_pin: pins.dc,

--- a/httpdocs/firmware/toolbox/simple-config-presets.json
+++ b/httpdocs/firmware/toolbox/simple-config-presets.json
@@ -1655,6 +1655,7 @@
          },
          "defaultDisplay": "ep73-spectra-800x480",
          "defaultPower": "battery-2000",
+         "defaultRotation": "2",
          "dataBus": {
             "instance_number": "0x0",
             "bus_type": "0x1",


### PR DESCRIPTION
Fixes #51.

### What

`createDisplayConfig()` hardcoded `rotation: '0'`, so the `config.rotation` field carried
by seven display presets was never read — dead data. This resolves rotation the same way
`transmission_modes` already is (driver board → display preset → `'0'`) and adds
`defaultRotation: "2"` to the Waveshare ESP32-S3-PhotoPainter.

Board-first precedence because the enclosure decides the viewing orientation, while a
`config.rotation` on a display preset describes a panel-level quirk. Happy to flip the
order if you see it the other way.

### Behaviour change

| board + display | before | after |
|---|---|---|
| `esp32-s3-wspp` + `ep73-spectra-800x480` | 0 | **2** — PhotoPainter renders upside down on its stand today |
| `esp32s3-xiao` + `uc8151-027-bwr` | 0 | **1** — the value that preset has always declared |
| every other board/display combination | 0 | 0 (unchanged) |

The `uc8151-027-bwr` row is a real behaviour change for existing users, not just a
cleanup — flagging it explicitly in case 0° is what that panel actually wants, in which
case the preset value should be dropped instead.

### Verification

- Replayed the resolution logic against `simple-config-presets.json` for every
  board/display pair; only the two rows above change.
- `node --check` on all three inline `<script>` blocks of `index.html` passes.
- `jq` parses `simple-config-presets.json`.
- Hardware: an ESP32-S3-PhotoPainter configured through the simple flow renders its boot
  screen inverted on its stand; writing rotation 2 by hand through **Advanced: edit
  packets** makes it read correctly.
