### PR TITLE
Implement sticky footer

### DIFF
--- a/httpdocs/common.css
+++ b/httpdocs/common.css
@@ -319,3 +319,21 @@ a:hover {
   height: 0;
 }
 
+/* Sticky footer for when the viewport is taller than the content */
+.page-inner {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#main-content {
+    flex-grow: 1;
+}
+
+.site-bar {
+    flex-shrink: 0;
+}
+
+.site-footer {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
Got a bit annoyed at seeing the footer floating above the bottom of the screen on my 1440p monitor when on short pages, like the BLE tester. This small change implements the "sticky footer" design pattern (forcing the minimum height of the content to the viewport height and anchoring the footer accordingly), changing this....

<img width="1091" height="1183" alt="image" src="https://github.com/user-attachments/assets/7e493fb7-5be6-4904-866a-7401fe5826b6" />

...to this: 

<img width="1091" height="1183" alt="image" src="https://github.com/user-attachments/assets/79399c7b-3b4a-4749-a6ab-4f0f4ca9b887" />