### PR TITLE
ci: only run automated workflows on the upstream repository

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,6 @@ concurrency:
 
 jobs:
   release-please:
-    # A push to a fork's main would otherwise cut releases there. Keep it to
-    # the upstream repository; `deploy` needs this job, so it is gated too.
     if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   release-please:
+    # A push to a fork's main would otherwise cut releases there. Keep it to
+    # the upstream repository; `deploy` needs this job, so it is gated too.
+    if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/sync-firmware-nrf54.yml
+++ b/.github/workflows/sync-firmware-nrf54.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   sync:
-    # Forks inherit the schedule and would open firmware-sync PRs against
-    # themselves. Keep it to the upstream repository.
     if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-firmware-nrf54.yml
+++ b/.github/workflows/sync-firmware-nrf54.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   sync:
+    # Forks inherit the schedule and would open firmware-sync PRs against
+    # themselves. Keep it to the upstream repository.
+    if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-firmware.yml
+++ b/.github/workflows/sync-firmware.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   sync:
-    # Forks inherit the schedule and would open firmware-sync PRs against
-    # themselves. Keep it to the upstream repository.
     if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-firmware.yml
+++ b/.github/workflows/sync-firmware.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   sync:
+    # Forks inherit the schedule and would open firmware-sync PRs against
+    # themselves. Keep it to the upstream repository.
+    if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-ftp.yml
+++ b/.github/workflows/sync-ftp.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   sync:
-    # Forks inherit the schedule but not the FTP secrets, so the nightly run
-    # only ever fails there. Keep it to the upstream repository.
     if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-ftp.yml
+++ b/.github/workflows/sync-ftp.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   sync:
+    # Forks inherit the schedule but not the FTP secrets, so the nightly run
+    # only ever fails there. Keep it to the upstream repository.
+    if: github.repository == 'OpenDisplay/opendisplay.org'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The three nightly sync workflows (`sync-ftp`, `sync-firmware`, `sync-firmware-nrf54`) and `release-please` currently fire on every fork of this repository. Forks do not have the FTP secrets, so `sync-ftp` and `sync-firmware` fail every single night; the ones that do succeed would open firmware-sync PRs against the fork itself, and a push to a fork's `main` would cut releases there.

This gates each of those jobs on `github.repository == 'OpenDisplay/opendisplay.org'`, so they no-op (skip) anywhere else. Nothing changes for this repository.

The `deploy` job in `release-please.yml` needs no guard of its own — it `needs` the gated job, so it is skipped along with it. `deploy-ftp.yml` is left alone: it only runs on `workflow_call`, a published release, or an explicit `workflow_dispatch`, none of which happen unattended on a fork.

Example of the nightly failures on a fork: https://github.com/balloob/opendisplay.org/actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1VYHyATdAB15ykhLVvYTH