### PR TITLE
add missing SHT40 sensor to reTerminal E1003 preset

### DIFF
--- a/httpdocs/firmware/toolbox/simple-config-presets.json
+++ b/httpdocs/firmware/toolbox/simple-config-presets.json
@@ -825,6 +825,13 @@
             "pulldowns": "0x0",
             "reserved": "0x0"
          },
+         "sensorData": {
+            "sensor_type": "4",
+            "instance_number": "0",
+            "bus_id": "0x0",
+            "i2c_addr_7bit": "0x44",
+            "msd_data_start_byte": "7"
+         },
          "touchController": {
             "instance_number": "0x0",
             "touch_ic_type": "1",


### PR DESCRIPTION
The reTerminal E1003 preset has no `sensorData` entry, so every E1003 provisioned through the toolbox gets a config without a `0x23` packet. The firmware therefore never polls the onboard SHT40, and the device never publishes temperature or humidity — the sensor is present but dead.

The E1001, E1002, E1004 and Sticky presets all declare their SHT40; the E1003 is the only reTerminal that does not.

## The E1003 does have an SHT40

Zephyr's board definition declares it on `&i2c0`:

```dts
sht40_temp: sht4x@44 {
    compatible = "sensirion,sht4x";
    reg = <0x44>;
};
```

Seeed's [E1003 specification table](https://wiki.seeedstudio.com/getting_started_with_reterminal_e1003/) also lists "Temperature, humidity sensors", and the [Zephyr board page](https://docs.zephyrproject.org/latest/boards/seeed/reterminal_e1003/doc/index.html) names "Sensirion SHT4x humidity and temperature sensor" in its hardware feature table.

## Why offset 7, not 1

The E1001/E1002/E1004 presets use `msd_data_start_byte: "1"`. That is safe on those boards because they have **no touch controller**. The E1003 does — its GT911 has `touch_data_start_byte: "1"` and occupies dynamic bytes 1–5, so offset 1 would have the SHT40 overwrite the touch block.

Offset 7 puts the reading in bytes 7–9:

| byte | owner |
|---|---|
| 0 | button |
| 1–5 | touch (GT911) |
| 6 | free |
| 7–9 | SHT40 |
| 10 | free |

This matches the Sticky preset, which also has touch and likewise uses 7.

The existing `dataBus` (I2C, SCL 20 / SDA 19) already serves this sensor, so no additional `0x24` packet is required.

## Verification

Applied these exact values to a live E1003 by exporting its config, adding the `0x23` packet, writing it back and rebooting. The device now reports:

```
├── Sensors
│   └── Sensor 0 SHT40  (bus 0)  28.0 °C  63.6 %RH
```

Confirmed from the broadcast advertisement that the slots do not collide:

```
dynamic: 00 00 00 00 00 00 00 7c a2 0a 00
         └0 button  └1-5 touch (idle)  └7-9 SHT40  └6,10 free
```