### PR TITLE
Implemented sticky footer, for real this time

### DIFF
--- a/httpdocs/common.css
+++ b/httpdocs/common.css
@@ -318,22 +318,3 @@ a:hover {
   width: 0;
   height: 0;
 }
-
-/* Sticky footer for when the viewport is taller than the content */
-.page-inner {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-}
-
-#main-content {
-    flex-grow: 1;
-}
-
-.site-bar {
-    flex-shrink: 0;
-}
-
-.site-footer {
-    flex-shrink: 0;
-}

--- a/httpdocs/css/home.css
+++ b/httpdocs/css/home.css
@@ -1483,6 +1483,26 @@ input[type=range].od-range::-moz-range-thumb {
 input[type=range].od-range:focus-visible { outline: none; }
 input[type=range].od-range:focus-visible::-webkit-slider-thumb { box-shadow: var(--shadow-focus); }
 
+/* Sticky footer for when the viewport is taller than the content  */
+.page-home {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#main-content {
+    flex-grow: 1;
+}
+
+.site-bar {
+    flex-shrink: 0;
+}
+
+.site-footer {
+    flex-shrink: 0;
+}
+
+
 /* Responsive */
 @media (max-width: 900px) {
   .hero__inner { grid-template-columns: 1fr; gap: 40px; }

--- a/httpdocs/css/inner.css
+++ b/httpdocs/css/inner.css
@@ -275,3 +275,22 @@ a.od-foot-link:hover {
   .tool-page { padding-top: 28px; }
   .site-footer__top { grid-template-columns: 1fr; }
 }
+
+/* Sticky footer for when the viewport is taller than the content */
+.page-inner {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#main-content {
+    flex-grow: 1;
+}
+
+.site-bar {
+    flex-shrink: 0;
+}
+
+.site-footer {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
[In my previous PR](https://github.com/OpenDisplay/opendisplay.org/pull/70) I added a little bit of CSS to `httpdocs/common.css` to implement sticky footer functionality on the website. As it turns out, that CSS file is not actually common at all and is only used on the few remaining pages bearing the old site design. Whoops.

This PR removes the sticky footer code from there and adds it instead to `inner.css` and `home.css`. 