### PR TITLE
Implement 7-color support to BLE tester

### DIFF
--- a/httpdocs/firmware/display/index.html
+++ b/httpdocs/firmware/display/index.html
@@ -675,7 +675,7 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
                 const h = v.toString(16).padStart(2, '0');
                 return '#' + h + h + h;
             }),
-            ['#000000', '#ffffff', '#ff0000', '#ffff00', '#00ff00', '#0000ff', '#ffa500'],
+            ['#000000', '#ffffff', '#ff0000', '#ffff00', '#00ff00', '#0000ff', '#ff8000'],
         ];
         PALETTE[8] = PALETTE[4]; // bwgbry_split — same Spectra 6 swatches
         const SCHEME_SHORT = {
@@ -2067,13 +2067,18 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
                 ctx.fillStyle = 'rgb(255, 255, 0)';  // Pure yellow - exact display color
                 ctx.fillText(text, x, y2);
             }
-            if (colorScheme === 4 || colorScheme === 8) {
+            if (colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
                 let y3 = y + fontSize * 1.4;
                 ctx.fillStyle = 'rgb(0, 255, 0)';  // Pure green - exact display color
                 ctx.fillText(text, x, y3);
                 let y4 = y - fontSize * 1.4;
                 ctx.fillStyle = 'rgb(0, 0, 255)';  // Pure blue - exact display color
                 ctx.fillText(text, x, y4);
+            }
+            if (colorScheme === 7) {
+                let y5 = y + fontSize * 2.1;
+                ctx.fillStyle = 'rgb(255, 128, 0)';  // Pure orange - exact display color
+                ctx.fillText(text, x, y5);
             }
             if (colorScheme === 5) {
                 let y2 = y + fontSize * 0.7;

--- a/httpdocs/firmware/display/index.html
+++ b/httpdocs/firmware/display/index.html
@@ -384,9 +384,10 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
                     <option value="2">B/W + Yellow</option>
                     <option value="3">B/W + Red + Yellow</option>
                     <option value="4" selected>B/W + Green + Blue + Red + Yellow (6-color)</option>
-                    <option value="8">6-color split (left half-plane then right; dual-CS)</option>
                     <option value="5">4 Grayscale</option>
                     <option value="6">16 Grayscale (4bpp)</option>
+                    <option value="7">B/W + Green + Blue + Red + Yellow + Orange (7-color)</option>
+                    <option value="8">6-color split (left half-plane then right; dual-CS)</option>
                 </select>
             </div>
         </div>
@@ -673,11 +674,12 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
                 const v = Math.round((k * 255) / 15);
                 const h = v.toString(16).padStart(2, '0');
                 return '#' + h + h + h;
-            })
+            }),
+            ['#000000', '#ffffff', '#ff0000', '#ffff00', '#00ff00', '#0000ff', '#ffa500'],
         ];
         PALETTE[8] = PALETTE[4]; // bwgbry_split — same Spectra 6 swatches
         const SCHEME_SHORT = {
-            0: 'BW', 1: 'BWR', 2: 'BWY', 3: 'BWRY', 4: '6C', 5: '4G', 6: '16G', 8: '6Cs'
+            0: 'BW', 1: 'BWR', 2: 'BWY', 3: 'BWRY', 4: '6C', 5: '4G', 6: '16G', 7: '7C', 8: '6Cs'
         };
         const SCHEME_NAMES = {
             0: 'Monochrome (B/W)',
@@ -687,11 +689,12 @@ button.color-swatch.selected:hover{box-shadow:0 0 0 2px var(--accent)!important}
             4: 'B/W + Green + Blue + Red + Yellow (6-color)',
             5: '4 Grayscale',
             6: '16 Grayscale (4bpp)',
+            7: 'B/W + Green + Blue + Red + Yellow + Orange (7-color)',
             8: '6-color split (left half-plane then right; dual-CS)'
         };
         function clampScheme(cs) {
             const n = parseInt(cs, 10);
-            if (n === 8) return 8;
+            if (n === 7 || n === 8) return n;
             if (Number.isNaN(n)) return 0;
             return Math.min(Math.max(n, 0), 6);
         }

--- a/httpdocs/js/ble-common.js
+++ b/httpdocs/js/ble-common.js
@@ -3434,8 +3434,8 @@ class OpenDisplayBLE {
    * @param {number} r - Red component (0-255)
    * @param {number} g - Green component (0-255)
    * @param {number} b - Blue component (0-255)
-   * @param {number} colorScheme - Color scheme (0-6)
-   * @returns {string} Color name ('black', 'white', 'red', 'yellow', 'green', 'blue')
+   * @param {number} colorScheme - Color scheme (0-8)
+   * @returns {string} Color name ('black', 'white', 'red', 'yellow', 'green', 'blue', 'orange')
    */
   detectColor(r, g, b, colorScheme) {
     if (colorScheme === 6) {
@@ -3459,19 +3459,23 @@ class OpenDisplayBLE {
     const colorYellow = [255, 255, 0];
     const colorGreen = [0, 255, 0];
     const colorBlue = [0, 0, 255];
+    const colorOrange = [255, 128, 0];
     const availableColors = [];
     
     availableColors.push({ color: colorBlack, name: 'black' });
     availableColors.push({ color: colorWhite, name: 'white' });
-    if (colorScheme === 1 || colorScheme === 3 || colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 1 || colorScheme === 3 || colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorRed, name: 'red' });
     }
-    if (colorScheme === 2 || colorScheme === 3 || colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 2 || colorScheme === 3 || colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorYellow, name: 'yellow' });
     }
-    if (colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorGreen, name: 'green' });
       availableColors.push({ color: colorBlue, name: 'blue' });
+    }
+    if (colorScheme === 7) {
+      availableColors.push({ color: colorOrange, name: 'orange' });
     }
     
     let minDist = Infinity;
@@ -3495,7 +3499,7 @@ class OpenDisplayBLE {
    * @param {number} r - Red component (0-255)
    * @param {number} g - Green component (0-255)
    * @param {number} b - Blue component (0-255)
-   * @param {number} colorScheme - Color scheme (0-6)
+   * @param {number} colorScheme - Color scheme (0-8)
    * @returns {Array} RGB array [r, g, b] of nearest color
    */
   findNearestColor(r, g, b, colorScheme) {
@@ -3523,18 +3527,22 @@ class OpenDisplayBLE {
     const colorYellow = [255, 255, 0];
     const colorGreen = [0, 255, 0];
     const colorBlue = [0, 0, 255];
+    const colorOrange = [255, 128, 0];
     const availableColors = [];
     availableColors.push({ color: colorBlack, name: 'black' });
     availableColors.push({ color: colorWhite, name: 'white' });
-    if (colorScheme === 1 || colorScheme === 3 || colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 1 || colorScheme === 3 || colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorRed, name: 'red' });
     }
-    if (colorScheme === 2 || colorScheme === 3 || colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 2 || colorScheme === 3 || colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorYellow, name: 'yellow' });
     }
-    if (colorScheme === 4 || colorScheme === 8) {
+    if (colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
       availableColors.push({ color: colorGreen, name: 'green' });
       availableColors.push({ color: colorBlue, name: 'blue' });
+    }
+    if (colorScheme === 7) {
+      availableColors.push({ color: colorOrange, name: 'orange' });
     }
     let minDist = Infinity;
     let nearestColor = colorWhite;
@@ -3666,7 +3674,7 @@ class OpenDisplayBLE {
   /**
    * Encode canvas to byte array for display
    * @param {HTMLCanvasElement} canvas - Canvas element
-   * @param {number} colorScheme - Color scheme (0-6)
+   * @param {number} colorScheme - Color scheme (0-8)
    * @param {number} rotation - Display rotation (0=0°, 1=90°, 2=180°, 3=270°)
    * @param {number} originalWidth - Original width before rotation
    * @param {number} originalHeight - Original height before rotation
@@ -3731,10 +3739,19 @@ class OpenDisplayBLE {
     
     const byteData = [];
     
-    if (colorScheme === 4 || colorScheme === 8) {
-      // 6-color scheme: 2 pixels per byte (nibbles). Scheme 8 (bwgbry_split) packs
+    if (colorScheme === 4 || colorScheme === 7 || colorScheme === 8) {
+      // 6-color and 7-color scheme: 2 pixels per byte (nibbles). Scheme 8 (bwgbry_split) packs
       // the left half-plane first (all rows' left bytes), then the right half-plane,
       // so dual-CS panels can stream CS1 then CS2 with no framebuffer.
+      //
+      // Schemes 4/8 (Spectra 6) and scheme 7 (ACeP) use different nibble codes for the same
+      // colors, so the table is selected per scheme rather than shared. Scheme 7
+      // keeps Spectra 6's yellow=2/red=3 but moves blue and green down to 4/5 to
+      // free 6 for orange
+      const sevenColor = colorScheme === 7;
+      const nibbleFor = sevenColor
+        ? { black: 0, white: 1, yellow: 2, red: 3, blue: 4, green: 5, orange: 6 }
+        : { black: 0, white: 1, yellow: 2, red: 3, blue: 5, green: 6 };
       const packRowMajor = (x0, x1) => {
         let currentByte = 0;
         let nibblePosition = 1;
@@ -3745,13 +3762,7 @@ class OpenDisplayBLE {
             const g = pixels[i + 1];
             const b = pixels[i + 2];
             const color = this.detectColor(r, g, b, colorScheme);
-            let colorValue = 0;
-            if (color === 'black') colorValue = 0;
-            else if (color === 'white') colorValue = 1;
-            else if (color === 'yellow') colorValue = 2;
-            else if (color === 'red') colorValue = 3;
-            else if (color === 'green') colorValue = 6;
-            else if (color === 'blue') colorValue = 5;
+            const colorValue = nibbleFor[color] ?? 0;
 
             if (nibblePosition === 1) {
               currentByte = (colorValue << 4);


### PR DESCRIPTION
These commits add the necessary schema changes and dithering patches to support 7 color displays (BW, yellow, red, blue, green, and orange). 

One thing to note is these are implemented against the behavior for 7 color displays in py-opendisplay. From what I've read, ACeP panels might have a different color order that will need to be changed in both projects when tested against real hardware. I don't have that kind of hardware, so I can't validate that at this time. It shouldn't be too hard to change, though; it's just one line of code that'd need to be changed in ble-common. 